### PR TITLE
feat: Add Simple Echo MCP

### DIFF
--- a/simple-echo-mcp/Dockerfile
+++ b/simple-echo-mcp/Dockerfile
@@ -1,0 +1,17 @@
+FROM tfy.jfrog.io/tfy-mirror/python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+ENV TRANSPORT=streamable-http
+EXPOSE 8000
+
+CMD python server.py ${TRANSPORT}

--- a/simple-echo-mcp/requirements.txt
+++ b/simple-echo-mcp/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp==3.1.0
+uvicorn==0.41.0

--- a/simple-echo-mcp/server.py
+++ b/simple-echo-mcp/server.py
@@ -1,0 +1,63 @@
+"""Unified MCP test server supporting all three transport variants.
+
+Usage:
+    python server.py streamable-http       # JSON responses (Variant 1)
+    python server.py streamable-http-sse   # SSE streaming responses (Variant 2)
+    python server.py sse                   # Legacy SSE (Variant 3)
+"""
+
+import argparse
+import logging
+import os
+
+import uvicorn
+from fastmcp import FastMCP
+from fastmcp.server.http import create_streamable_http_app
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mcp-test-server")
+
+mcp = FastMCP("test-echo-server")
+
+
+class LogHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        logger.info("--- Incoming %s %s ---", request.method, request.url.path)
+        for name, value in request.headers.items():
+            logger.info("  %s: %s", name, value)
+        return await call_next(request)
+
+
+@mcp.tool()
+def echo(message: str) -> str:
+    """Echoes back the input"""
+    return f"echoed: {message}"
+
+
+def create_json_app():
+    app = create_streamable_http_app(mcp, streamable_http_path="/mcp", json_response=True)
+    app.add_middleware(LogHeadersMiddleware)
+    return app
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("transport", choices=["streamable-http", "streamable-http-sse", "sse"])
+    args = parser.parse_args()
+
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8000"))
+
+    if args.transport == "streamable-http":
+        uvicorn.run(
+            "server:create_json_app",
+            factory=True,
+            host=host,
+            port=port,
+        )
+    elif args.transport == "streamable-http-sse":
+        mcp.run(transport="streamable-http", host=host, port=port)
+    elif args.transport == "sse":
+        mcp.run(transport="sse", host=host, port=port)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new, self-contained MCP echo server and Docker image; changes are isolated and primarily affect local/test deployment.
> 
> **Overview**
> Adds a new `simple-echo-mcp` package that runs a minimal FastMCP `echo` tool for testing MCP clients.
> 
> Provides a `server.py` entrypoint that supports `streamable-http` (JSON via `uvicorn` + `create_streamable_http_app`), `streamable-http-sse`, and legacy `sse`, including request-header logging middleware.
> 
> Includes a `Dockerfile` and pinned `requirements.txt` to build and run the server with `TRANSPORT` configurable via environment variables (default `streamable-http`) and port `8000` exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c8b2b99db039b95d7a7697f8795d7e1e4a3e034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->