### PR TITLE
feat: added m365 mcp server

### DIFF
--- a/m365-mcp/.dockerignore
+++ b/m365-mcp/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+npm-debug.log*
+.git
+.gitignore
+.dockerignore
+Dockerfile
+*.md
+.env
+.env.*
+.DS_Store
+coverage
+.vscode
+.idea
+tmp
+*.log
+test

--- a/m365-mcp/.gitignore
+++ b/m365-mcp/.gitignore
@@ -1,0 +1,251 @@
+# ---- Node.js -----------------------------------------------------------
+# Dependencies
+node_modules/
+.npm
+.pnp
+.pnp.js
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build output / caches
+dist/
+build/
+coverage/
+*.tsbuildinfo
+.eslintcache
+
+# Environment files (keep secrets/tokens out of git)
+.env
+.env.*
+!.env.example
+
+# Editor / OS cruft
+.DS_Store
+.vscode/
+.idea/
+
+# ---- Python (template defaults, kept for completeness) -----------------
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+# Temporary file for partial code execution
+tempCodeRunnerFile.py
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/m365-mcp/.tfyignore
+++ b/m365-mcp/.tfyignore
@@ -1,0 +1,44 @@
+# Files excluded from the LocalSource(local_build=False) upload to TrueFoundry.
+#
+# The TFY CLI looks for this file first; if absent it falls back to .gitignore
+# (when source is a git repo) or no filter at all. .dockerignore is NOT used
+# by the upload step - only by `docker build` inside the image.
+#
+# Keep this in sync with .dockerignore as a defense-in-depth layer. NOTE: src/
+# IS shipped (this server runs `node src/index.js` directly, no build step).
+
+# Dependencies - reinstalled inside the image via `npm ci`
+node_modules/
+.cache/
+
+# Tests - not needed in the deployed image
+test/
+
+# VCS / IDE / OS
+.git/
+.gitignore
+.gitattributes
+.github/
+.npmignore
+.vscode/
+.idea/
+.claude/
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Local env / secrets - NEVER ship to the build context
+.env
+.env.*
+!.env.example
+
+# Local-only assets
+deploy.py
+README.md

--- a/m365-mcp/Dockerfile
+++ b/m365-mcp/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+# ---- deps: install production dependencies only ----------------------------
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# ---- runtime ---------------------------------------------------------------
+FROM node:22-alpine AS runtime
+ENV NODE_ENV=production \
+    PORT=3000
+WORKDIR /app
+
+# Bring in the pruned node_modules and application source.
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json package-lock.json ./
+COPY src ./src
+
+# Run as the unprivileged user that ships with the node image.
+USER node
+
+EXPOSE 3000
+
+# Container-level liveness check hitting the /health endpoint.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "src/index.js"]

--- a/m365-mcp/README.md
+++ b/m365-mcp/README.md
@@ -1,0 +1,171 @@
+# m365-mcp-server
+
+A Node.js [MCP](https://modelcontextprotocol.io) server exposing **Microsoft 365**
+capabilities (Outlook Mail, Calendar, Teams, OneDrive, SharePoint) as tools,
+backed by the [Microsoft Graph API](https://learn.microsoft.com/graph/).
+
+It runs over the **Streamable HTTP** transport and passes the caller's OAuth
+**Bearer token straight through to Graph** — the server performs no token
+exchange, storage, or caching, and is fully stateless (a fresh MCP server +
+transport is built per request so tokens never leak between callers).
+
+## Requirements
+
+- Node.js >= 18 (uses the global `fetch`)
+- A valid Microsoft Graph access token with the scopes for the tools you call
+
+## Setup
+
+```bash
+npm install
+npm start          # listens on http://localhost:3000  (set PORT to override)
+```
+
+## Endpoints
+
+| Method | Path      | Auth            | Description                          |
+| ------ | --------- | --------------- | ------------------------------------ |
+| `GET`  | `/health` | none            | Liveness check (`{"status":"ok"}`).  |
+| `POST` | `/mcp`    | `Bearer <jwt>`  | MCP Streamable HTTP endpoint.        |
+
+The `Authorization: Bearer <token>` header is **required** on `/mcp`. Missing or
+malformed headers return JSON-RPC error `-32001` with HTTP 401.
+
+## Tools
+
+### 📧 Outlook Mail
+| Tool | Description |
+| --- | --- |
+| `list_emails` | List emails with filters (folder, unread, top) |
+| `search_emails` | KQL search across the mailbox (query, from, date_range) |
+| `get_email` | Get a full email by id |
+| `send_email` | Send a new email |
+| `reply_email` | Reply / reply-all to a thread |
+| `create_draft` | Create a draft email |
+| `update_draft` | Update an existing draft |
+| `delete_email` | Delete (move to Deleted Items) |
+| `list_folders` | List mailbox folders |
+| `move_email` | Move an email to a folder |
+
+### 📅 Outlook Calendar
+| Tool | Description |
+| --- | --- |
+| `list_events` | List upcoming events |
+| `search_events` | Search events by keyword / date range |
+| `get_event` | Get event details by id |
+| `create_event` | Create an event (optionally a Teams meeting) |
+| `update_event` | Update an existing event |
+| `delete_event` | Delete an event |
+| `accept_event` | Accept a meeting invitation |
+| `decline_event` | Decline a meeting invitation |
+| `find_free_slots` | Free/busy lookup via `getSchedule` |
+| `list_calendars` | List the user's calendars |
+
+### 💬 Microsoft Teams
+| Tool | Description |
+| --- | --- |
+| `list_chats` | List the user's chats |
+| `search_chat_messages` | Search across chat messages |
+| `get_chat_messages` | Get messages from a chat |
+| `send_chat_message` | Post a message to a chat |
+| `create_chat` | Create a new chat |
+| `add_chat_member` | Add a member to a chat |
+| `list_teams` | List joined teams |
+| `list_channels` | List channels in a team |
+| `get_channel_messages` | Read channel messages |
+| `post_channel_message` | Post to a channel |
+
+### 📁 OneDrive
+| Tool | Description |
+| --- | --- |
+| `list_files` | List files in a folder |
+| `search_files` | Search files by name / content |
+| `get_file` | Get file metadata |
+| `download_file` | Download file content (base64) |
+| `upload_file` | Upload a small file (< 4 MB, base64) |
+| `create_folder` | Create a new folder |
+| `delete_file` | Delete a file or folder |
+| `move_file` | Move / rename a file |
+| `share_file` | Create a sharing link |
+
+### 🌐 SharePoint
+| Tool | Description |
+| --- | --- |
+| `search_sharepoint` | Full-text search across the tenant |
+| `list_sites` | List / search SharePoint sites |
+| `get_site` | Get site details |
+| `list_libraries` | List document libraries (drives) |
+| `list_items` | List items in a list |
+| `get_item` | Get a specific list item |
+| `create_item` | Create a list item |
+| `update_item` | Update a list item |
+| `upload_to_sharepoint` | Upload a file to a site library |
+
+## Required Graph scopes
+
+Grant the access token the delegated scopes for the surfaces you use, e.g.
+`Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `Chat.ReadWrite`,
+`ChannelMessage.Read.All`/`Send`, `Files.ReadWrite.All`, `Sites.ReadWrite.All`.
+
+## Project layout
+
+```
+src/
+  index.js            Express app, Bearer extraction, Streamable HTTP transport
+  graph.js            Microsoft Graph client (GET/POST/PATCH/PUT/DELETE, upload/download, search)
+  tools/
+    index.js          Registers every service module
+    util.js           Shared MCP helpers and zod schemas
+    mail.js           Outlook Mail tools
+    calendar.js       Outlook Calendar tools
+    teams.js          Microsoft Teams tools
+    onedrive.js       OneDrive tools
+    sharepoint.js     SharePoint tools
+```
+
+## Example request
+
+```bash
+# Health
+curl http://localhost:3000/health
+
+# List tools
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer $GRAPH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+## Configuration
+
+All optional, with production-safe defaults:
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `PORT` | `3000` | HTTP listen port. |
+| `GRAPH_TIMEOUT_MS` | `30000` | Per-attempt timeout for each Graph request. |
+| `GRAPH_MAX_RETRIES` | `3` | Extra retries on `429`/`503`/`504` and network/timeout errors (backs off, honoring `Retry-After`). |
+| `GRAPH_MAX_TRANSFER_BYTES` | `4194304` (4 MB) | Cap on bytes buffered in memory for a single up/download. |
+| `MAX_BODY_SIZE` | `8mb` | Express JSON body limit (headroom for base64-inflated uploads). |
+
+## Testing
+
+```bash
+npm test   # node:test runner — pure-helper unit tests + an end-to-end smoke test
+```
+
+## Notes
+
+- Uploads (`upload_file`, `upload_to_sharepoint`) use a simple PUT and are
+  limited to `GRAPH_MAX_TRANSFER_BYTES` (~4 MB); larger files require a Graph
+  upload session. Base64 inflates the request ~33%, so the JSON body limit
+  (`MAX_BODY_SIZE`) is set above that.
+- Transient Graph failures (throttling/`5xx`/network/timeout) are retried with
+  backoff; each attempt is bounded by `GRAPH_TIMEOUT_MS`.
+- `search_*` tools use `$search` / the Microsoft Search API and require the
+  token to carry the relevant read scopes.
+- Graph errors are surfaced as MCP tool errors (`isError: true`) with the HTTP
+  status and Graph's message, rather than crashing the request.
+- On `SIGTERM`/`SIGINT` the server stops accepting connections and drains
+  in-flight requests (10s hard timeout) for clean Kubernetes rollouts.

--- a/m365-mcp/deploy.py
+++ b/m365-mcp/deploy.py
@@ -1,55 +1,36 @@
 """
-Deploy m365-mcp to TrueFoundry from the local working copy.
+Deploy m365-mcp to TrueFoundry (prod: tfy-prod-euwe1:mcp-servers).
 
 Usage:
-    1. tfy login --host https://internal.devtest.truefoundry.tech
+    1. tfy login --host https://internal.truefoundry.cloud
     2. python deploy.py
-
-Overrides (optional env vars):
-    WORKSPACE_FQN  -> target workspace, "<cluster>:<workspace>" form.
-    SERVICE_HOST   -> public host for the exposed port.
 
 Notes:
     - This MCP server holds NO Microsoft credentials. The TFY LLM Gateway runs
-      the OAuth flow against your Entra ID app registration and forwards the
+      the OAuth flow against the Entra ID app registration and forwards the
       resulting per-user Graph access token in the Authorization header. The pod
-      just passes that bearer straight through to Microsoft Graph and is fully
-      stateless.
-
-This uses LocalSource(local_build=False), so TrueFoundry zips this directory
-(respecting .tfyignore), uploads it, builds the image remotely, and deploys.
-.dockerignore is a second filter that runs inside `docker build` itself. Unlike
-the TypeScript servers in this repo, m365-mcp is plain JS and runs straight from
-`src/` via `node src/index.js` (no build step), so node_modules is reinstalled
-inside the image by `npm ci`.
+      passes that bearer straight through to Microsoft Graph and is stateless.
+    - LocalSource(local_build=False): TrueFoundry zips this directory (respecting
+      .tfyignore), uploads it, and builds the image remotely. m365-mcp is plain
+      JS and runs straight from src/ via `node src/index.js` (no build step);
+      node_modules is reinstalled inside the image by `npm ci`.
 """
 
 import logging
-import os
 
 from truefoundry.deploy import (
-    Build,
     DockerFileBuild,
     HealthProbe,
     HttpProbe,
     LocalSource,
-    NodeSelector,
     Port,
-    Resources,
     Service,
+    Resources,
+    Build,
+    NodeSelector,
 )
 
 logging.basicConfig(level=logging.INFO)
-
-# ---- EDIT THESE -------------------------------------------------------------
-# Deploying into the harsh-ws workspace. Confirm the cluster/host for your
-# environment and override via env vars if they differ.
-WORKSPACE_FQN = os.environ.get("WORKSPACE_FQN", "tfy-usea1-devtest:harsh-ws")
-SERVICE_HOST = os.environ.get(
-    "SERVICE_HOST",
-    "m365-mcp-harsh-ws-3000.tfy-usea1-ctl.devtest.truefoundry.tech",
-)
-# ----------------------------------------------------------------------------
 
 service = Service(
     name="m365-mcp",
@@ -62,43 +43,43 @@ service = Service(
         ),
     ),
     resources=Resources(
-        cpu_request=0.1,
-        cpu_limit=0.5,
-        memory_request=256,
-        memory_limit=1024,
-        ephemeral_storage_request=500,
-        ephemeral_storage_limit=500,
+        cpu_request=0.2,
+        cpu_limit=1.0,
+        memory_request=200,
+        memory_limit=500,
+        ephemeral_storage_request=1000,
+        ephemeral_storage_limit=2000,
         node=NodeSelector(capacity_type="spot_fallback_on_demand"),
     ),
-    env={
-        "PORT": "3000",
-    },
+    env={"PORT": "3000"},
     ports=[
         Port(
             port=3000,
             protocol="TCP",
             expose=True,
             app_protocol="http",
-            host=SERVICE_HOST,
+            host="m365.mcp.truefoundry.com",
         )
     ],
     liveness_probe=HealthProbe(
         config=HttpProbe(path="/health", port=3000),
+        initial_delay_seconds=10,
         period_seconds=10,
         timeout_seconds=1,
-        failure_threshold=3,
         success_threshold=1,
-        initial_delay_seconds=10,
+        failure_threshold=3,
     ),
     readiness_probe=HealthProbe(
         config=HttpProbe(path="/health", port=3000),
+        initial_delay_seconds=5,
         period_seconds=10,
         timeout_seconds=1,
-        failure_threshold=3,
         success_threshold=1,
-        initial_delay_seconds=5,
+        failure_threshold=3,
     ),
+    workspace_fqn="tfy-prod-euwe1:mcp-servers",
     replicas=1.0,
 )
 
-service.deploy(workspace_fqn=WORKSPACE_FQN, wait=False)
+
+service.deploy(workspace_fqn="tfy-prod-euwe1:mcp-servers", wait=False)

--- a/m365-mcp/deploy.py
+++ b/m365-mcp/deploy.py
@@ -1,0 +1,104 @@
+"""
+Deploy m365-mcp to TrueFoundry from the local working copy.
+
+Usage:
+    1. tfy login --host https://internal.devtest.truefoundry.tech
+    2. python deploy.py
+
+Overrides (optional env vars):
+    WORKSPACE_FQN  -> target workspace, "<cluster>:<workspace>" form.
+    SERVICE_HOST   -> public host for the exposed port.
+
+Notes:
+    - This MCP server holds NO Microsoft credentials. The TFY LLM Gateway runs
+      the OAuth flow against your Entra ID app registration and forwards the
+      resulting per-user Graph access token in the Authorization header. The pod
+      just passes that bearer straight through to Microsoft Graph and is fully
+      stateless.
+
+This uses LocalSource(local_build=False), so TrueFoundry zips this directory
+(respecting .tfyignore), uploads it, builds the image remotely, and deploys.
+.dockerignore is a second filter that runs inside `docker build` itself. Unlike
+the TypeScript servers in this repo, m365-mcp is plain JS and runs straight from
+`src/` via `node src/index.js` (no build step), so node_modules is reinstalled
+inside the image by `npm ci`.
+"""
+
+import logging
+import os
+
+from truefoundry.deploy import (
+    Build,
+    DockerFileBuild,
+    HealthProbe,
+    HttpProbe,
+    LocalSource,
+    NodeSelector,
+    Port,
+    Resources,
+    Service,
+)
+
+logging.basicConfig(level=logging.INFO)
+
+# ---- EDIT THESE -------------------------------------------------------------
+# Deploying into the harsh-ws workspace. Confirm the cluster/host for your
+# environment and override via env vars if they differ.
+WORKSPACE_FQN = os.environ.get("WORKSPACE_FQN", "tfy-usea1-devtest:harsh-ws")
+SERVICE_HOST = os.environ.get(
+    "SERVICE_HOST",
+    "m365-mcp-harsh-ws-3000.tfy-usea1-ctl.devtest.truefoundry.tech",
+)
+# ----------------------------------------------------------------------------
+
+service = Service(
+    name="m365-mcp",
+    image=Build(
+        build_source=LocalSource(local_build=False),
+        build_spec=DockerFileBuild(
+            dockerfile_path="./Dockerfile",
+            build_context_path="./",
+            command="node src/index.js",
+        ),
+    ),
+    resources=Resources(
+        cpu_request=0.1,
+        cpu_limit=0.5,
+        memory_request=256,
+        memory_limit=1024,
+        ephemeral_storage_request=500,
+        ephemeral_storage_limit=500,
+        node=NodeSelector(capacity_type="spot_fallback_on_demand"),
+    ),
+    env={
+        "PORT": "3000",
+    },
+    ports=[
+        Port(
+            port=3000,
+            protocol="TCP",
+            expose=True,
+            app_protocol="http",
+            host=SERVICE_HOST,
+        )
+    ],
+    liveness_probe=HealthProbe(
+        config=HttpProbe(path="/health", port=3000),
+        period_seconds=10,
+        timeout_seconds=1,
+        failure_threshold=3,
+        success_threshold=1,
+        initial_delay_seconds=10,
+    ),
+    readiness_probe=HealthProbe(
+        config=HttpProbe(path="/health", port=3000),
+        period_seconds=10,
+        timeout_seconds=1,
+        failure_threshold=3,
+        success_threshold=1,
+        initial_delay_seconds=5,
+    ),
+    replicas=1.0,
+)
+
+service.deploy(workspace_fqn=WORKSPACE_FQN, wait=False)

--- a/m365-mcp/package-lock.json
+++ b/m365-mcp/package-lock.json
@@ -1,0 +1,1547 @@
+{
+  "name": "m365-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "m365-mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "express": "^4.21.2",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/m365-mcp/package.json
+++ b/m365-mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "m365-mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server exposing Microsoft 365 (Graph API) search tools over Streamable HTTP with Bearer token pass-through.",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "node --watch src/index.js",
+    "test": "node --test \"test/*.test.js\""
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "express": "^4.21.2",
+    "zod": "^3.24.1"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/m365-mcp/src/graph.js
+++ b/m365-mcp/src/graph.js
@@ -245,7 +245,7 @@ export async function graphDownload(token, path) {
     throw new GraphError(res.status, detail);
   }
 
-  // Reject oversized files before buffering them into memory.
+  // Fast path: reject when the server declares an oversize length up front.
   const declared = Number(res.headers.get("content-length"));
   if (declared && declared > MAX_TRANSFER_BYTES) {
     throw new GraphError(
@@ -255,13 +255,34 @@ export async function graphDownload(token, path) {
     );
   }
 
-  const buf = Buffer.from(await res.arrayBuffer());
-  if (buf.length > MAX_TRANSFER_BYTES) {
-    throw new GraphError(
-      413,
-      `File is ${buf.length} bytes, over the ${MAX_TRANSFER_BYTES}-byte download limit.`,
-    );
+  // Don't trust Content-Length alone — storage redirects often omit or
+  // misreport it. Stream the body and enforce the cap as bytes arrive so an
+  // oversize download can't be fully buffered into memory before the check.
+  const chunks = [];
+  let total = 0;
+  if (res.body) {
+    const reader = res.body.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.length;
+        if (total > MAX_TRANSFER_BYTES) {
+          throw new GraphError(
+            413,
+            `File exceeds the ${MAX_TRANSFER_BYTES}-byte download limit. ` +
+              "Use a Graph download session for large files.",
+          );
+        }
+        chunks.push(Buffer.from(value));
+      }
+    } finally {
+      // Release the connection if we stopped early (e.g. hit the cap).
+      await reader.cancel().catch(() => {});
+    }
   }
+
+  const buf = Buffer.concat(chunks);
   return {
     contentType: res.headers.get("content-type") || "application/octet-stream",
     sizeBytes: buf.length,

--- a/m365-mcp/src/graph.js
+++ b/m365-mcp/src/graph.js
@@ -1,0 +1,270 @@
+/**
+ * Thin Microsoft Graph API client.
+ *
+ * The caller's Bearer token is passed straight through to Graph as the
+ * Authorization header — this server performs no token exchange or caching.
+ *
+ * Hardening for production use:
+ *  - every request has a wall-clock timeout (AbortController);
+ *  - transient failures (429/503/504, network/timeout) are retried with
+ *    exponential backoff that honors any Retry-After header;
+ *  - up/downloads are capped so a single large file can't OOM the pod.
+ */
+
+const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
+
+/** Per-attempt request timeout (ms). */
+const REQUEST_TIMEOUT_MS = Number(process.env.GRAPH_TIMEOUT_MS) || 30_000;
+/** Extra attempts after the first for transient failures. */
+const MAX_RETRIES = Number(process.env.GRAPH_MAX_RETRIES) || 3;
+/** Cap on bytes buffered in memory for a single up/download (simple PUT). */
+export const MAX_TRANSFER_BYTES =
+  Number(process.env.GRAPH_MAX_TRANSFER_BYTES) || 4 * 1024 * 1024;
+
+/**
+ * Error thrown when Graph returns a non-2xx response. Carries the HTTP status
+ * so the transport layer can surface meaningful messages to the MCP client.
+ */
+export class GraphError extends Error {
+  constructor(status, message, body) {
+    super(message);
+    this.name = "GraphError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/** Resolve a path to an absolute Graph URL and apply query params. */
+function buildUrl(path, query = {}) {
+  const url = new URL(path.startsWith("http") ? path : GRAPH_BASE + path);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && value !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Statuses worth retrying: throttling and transient gateway errors. */
+function isRetryable(status) {
+  return status === 429 || status === 503 || status === 504;
+}
+
+/**
+ * Backoff before the next attempt. Honors a Retry-After header (delta-seconds
+ * or HTTP date) when present, otherwise exponential backoff with jitter.
+ */
+function retryDelayMs(res, attempt) {
+  const header = res?.headers?.get("retry-after");
+  if (header) {
+    const seconds = Number(header);
+    if (!Number.isNaN(seconds)) return seconds * 1000;
+    const when = Date.parse(header);
+    if (!Number.isNaN(when)) return Math.max(0, when - Date.now());
+  }
+  return Math.min(2 ** attempt * 500, 10_000) + Math.floor(Math.random() * 250);
+}
+
+/** fetch() with a per-attempt timeout via AbortController. */
+async function fetchWithTimeout(url, init) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Issue a request with a timeout, retrying transient failures (429/503/504 and
+ * network/timeout errors) with backoff. Returns the final Response — which may
+ * still be non-2xx for the caller to map. Throws GraphError only when every
+ * attempt fails to produce a response.
+ */
+async function sendWithRetry(url, init) {
+  let lastError;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let res;
+    try {
+      res = await fetchWithTimeout(url, init);
+    } catch (err) {
+      lastError =
+        err?.name === "AbortError"
+          ? new GraphError(0, `Graph request timed out after ${REQUEST_TIMEOUT_MS}ms`)
+          : new GraphError(0, `Network error calling Graph: ${err.message}`);
+      if (attempt < MAX_RETRIES) {
+        await sleep(retryDelayMs(null, attempt));
+        continue;
+      }
+      throw lastError;
+    }
+
+    if (isRetryable(res.status) && attempt < MAX_RETRIES) {
+      await sleep(retryDelayMs(res, attempt));
+      continue;
+    }
+    return res;
+  }
+  // Unreachable: the loop either returns a Response or throws above.
+  throw lastError ?? new GraphError(0, "Graph request failed");
+}
+
+/**
+ * Core request helper. Handles auth, JSON (de)serialization and error mapping.
+ *
+ * @param {string} token   Raw bearer token (no "Bearer " prefix).
+ * @param {string} method  HTTP method.
+ * @param {string} path    Path beginning with "/" or an absolute URL.
+ * @param {object} [opts]
+ * @param {Record<string, unknown>} [opts.query]    Query-string params.
+ * @param {unknown}                 [opts.body]     JSON request body.
+ * @param {Buffer|Uint8Array|string}[opts.rawBody]  Raw body (skips JSON encode).
+ * @param {Record<string,string>}   [opts.headers]  Extra request headers.
+ */
+async function graphRequest(token, method, path, opts = {}) {
+  const { query, body, rawBody, headers = {} } = opts;
+  const url = buildUrl(path, query);
+
+  const init = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      ...headers,
+    },
+  };
+
+  if (rawBody !== undefined) {
+    init.body = rawBody;
+  } else if (body !== undefined) {
+    init.headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+
+  const res = await sendWithRetry(url, init);
+
+  // 204 No Content (common for DELETE/PATCH-less updates) — nothing to parse.
+  if (res.status === 204) return { status: 204, ok: true };
+
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { raw: text };
+  }
+
+  if (!res.ok) {
+    const detail =
+      json?.error?.message || res.statusText || "Unknown Graph error";
+    throw new GraphError(res.status, detail, json);
+  }
+
+  return json;
+}
+
+export const graphGet = (token, path, query, headers) =>
+  graphRequest(token, "GET", path, { query, headers });
+
+export const graphPost = (token, path, body, headers) =>
+  graphRequest(token, "POST", path, { body, headers });
+
+export const graphPatch = (token, path, body, headers) =>
+  graphRequest(token, "PATCH", path, { body, headers });
+
+export const graphPut = (token, path, body, headers) =>
+  graphRequest(token, "PUT", path, { body, headers });
+
+export const graphDelete = (token, path, headers) =>
+  graphRequest(token, "DELETE", path, { headers });
+
+/**
+ * Query the Microsoft Search API for the given entity types.
+ * Powers cross-service SharePoint and Teams search.
+ *
+ * @param {string} token
+ * @param {string[]} entityTypes  e.g. ["driveItem", "listItem", "site"].
+ * @param {string} query          KQL / free-text query string.
+ * @param {number} [size]         Max results to return.
+ */
+export function microsoftSearch(token, entityTypes, query, size = 25) {
+  return graphPost(token, "/search/query", {
+    requests: [
+      { entityTypes, query: { queryString: query }, from: 0, size },
+    ],
+  });
+}
+
+/**
+ * Upload raw bytes to a Graph drive `.../content` endpoint via PUT.
+ * Suitable for small files (< 4 MB); larger files need an upload session.
+ *
+ * @param {string} token
+ * @param {string} path             Drive content path ending in "/content".
+ * @param {Buffer|Uint8Array} bytes Raw file bytes.
+ * @param {string} [contentType]    MIME type of the upload.
+ */
+export function graphUpload(token, path, bytes, contentType = "application/octet-stream") {
+  if (bytes.length > MAX_TRANSFER_BYTES) {
+    throw new GraphError(
+      413,
+      `File is ${bytes.length} bytes, over the ${MAX_TRANSFER_BYTES}-byte simple-upload limit. ` +
+        "Larger files require a Graph upload session.",
+    );
+  }
+  return graphRequest(token, "PUT", path, {
+    rawBody: bytes,
+    headers: { "Content-Type": contentType },
+  });
+}
+
+/**
+ * Download raw bytes from a Graph `.../content` endpoint and return them
+ * base64-encoded, following Graph's redirect to the storage backend.
+ *
+ * @returns {Promise<{ contentType: string, sizeBytes: number, base64: string }>}
+ */
+export async function graphDownload(token, path) {
+  const res = await sendWithRetry(buildUrl(path), {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}` },
+    redirect: "follow",
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    let detail = res.statusText;
+    try {
+      detail = JSON.parse(text)?.error?.message || detail;
+    } catch {
+      /* keep statusText */
+    }
+    throw new GraphError(res.status, detail);
+  }
+
+  // Reject oversized files before buffering them into memory.
+  const declared = Number(res.headers.get("content-length"));
+  if (declared && declared > MAX_TRANSFER_BYTES) {
+    throw new GraphError(
+      413,
+      `File is ${declared} bytes, over the ${MAX_TRANSFER_BYTES}-byte download limit. ` +
+        "Use a Graph download session for large files.",
+    );
+  }
+
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length > MAX_TRANSFER_BYTES) {
+    throw new GraphError(
+      413,
+      `File is ${buf.length} bytes, over the ${MAX_TRANSFER_BYTES}-byte download limit.`,
+    );
+  }
+  return {
+    contentType: res.headers.get("content-type") || "application/octet-stream",
+    sizeBytes: buf.length,
+    base64: buf.toString("base64"),
+  };
+}

--- a/m365-mcp/src/index.js
+++ b/m365-mcp/src/index.js
@@ -1,0 +1,115 @@
+/**
+ * Microsoft 365 MCP server.
+ *
+ * Exposes Graph-backed search tools over the MCP Streamable HTTP transport.
+ * Each request must carry an OAuth bearer token in the Authorization header;
+ * that token is passed straight through to Microsoft Graph. The server is
+ * stateless — a fresh McpServer + transport is built per request so tokens
+ * never leak between callers.
+ */
+
+import express from "express";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { registerTools } from "./tools/index.js";
+
+const PORT = Number(process.env.PORT) || 3000;
+
+/** Pull the raw token out of an "Authorization: Bearer <token>" header. */
+function extractBearer(req) {
+  const header = req.headers["authorization"] || req.headers["Authorization"];
+  if (!header || typeof header !== "string") return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+/** JSON-RPC error envelope helper. */
+function rpcError(res, status, code, message, id = null) {
+  res.status(status).json({
+    jsonrpc: "2.0",
+    error: { code, message },
+    id,
+  });
+}
+
+const app = express();
+// Base64 inflates payloads ~33%, so a 4 MB file (the simple-upload cap) needs
+// headroom above 4 MB of JSON. Keep this above MAX_TRANSFER_BYTES * 1.34.
+app.use(express.json({ limit: process.env.MAX_BODY_SIZE || "8mb" }));
+
+// Health check — no auth required.
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "m365-mcp-server", time: new Date().toISOString() });
+});
+
+// Main MCP endpoint. Stateless: build server + transport per request.
+app.post("/mcp", async (req, res) => {
+  const token = extractBearer(req);
+  if (!token) {
+    return rpcError(
+      res,
+      401,
+      -32001,
+      "Missing or malformed Authorization header. Expected 'Bearer <token>'.",
+      req.body?.id ?? null,
+    );
+  }
+
+  const server = new McpServer({
+    name: "m365-mcp-server",
+    version: "1.0.0",
+  });
+  registerTools(server, token);
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless mode
+  });
+
+  res.on("close", () => {
+    transport.close();
+    server.close();
+  });
+
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (err) {
+    console.error("Error handling MCP request:", err);
+    if (!res.headersSent) {
+      rpcError(res, 500, -32603, "Internal server error", req.body?.id ?? null);
+    }
+  }
+});
+
+// Streamable HTTP also defines GET (server->client stream) and DELETE
+// (session teardown). In stateless mode we don't keep sessions, so reject.
+const methodNotAllowed = (_req, res) => {
+  rpcError(res, 405, -32000, "Method not allowed. Use POST /mcp.");
+};
+app.get("/mcp", methodNotAllowed);
+app.delete("/mcp", methodNotAllowed);
+
+const httpServer = app.listen(PORT, () => {
+  console.log(`m365-mcp-server listening on http://localhost:${PORT}`);
+  console.log(`  MCP endpoint:   POST http://localhost:${PORT}/mcp`);
+  console.log(`  Health check:   GET  http://localhost:${PORT}/health`);
+});
+
+// Graceful shutdown for Kubernetes rollouts: stop accepting new connections and
+// let in-flight requests drain, with a hard timeout as a safety net.
+function shutdown(signal) {
+  console.log(`Received ${signal}, shutting down...`);
+  httpServer.close((err) => {
+    if (err) {
+      console.error("Error during shutdown:", err);
+      process.exit(1);
+    }
+    process.exit(0);
+  });
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout.");
+    process.exit(1);
+  }, 10_000).unref();
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/m365-mcp/src/tools/calendar.js
+++ b/m365-mcp/src/tools/calendar.js
@@ -1,3 +1,4 @@
+
 /**
  * Outlook Calendar tools (Microsoft Graph /me/events, /me/calendar*).
  */
@@ -9,7 +10,7 @@ import {
   graphPatch,
   graphDelete,
 } from "../graph.js";
-import { runTool, dateRangeSchema, odataString, searchPhrase } from "./util.js";
+import { runTool, dateRangeSchema, odataString } from "./util.js";
 
 const EVENT_SELECT =
   "id,subject,organizer,start,end,location,bodyPreview,webLink,attendees,isAllDay,isCancelled,onlineMeeting";
@@ -93,16 +94,25 @@ export function registerCalendarTools(server, token) {
       date_range: dateRangeSchema,
     },
     runTool(async ({ query, date_range }) => {
-      if (date_range && (date_range.start || date_range.end)) {
-        const start = date_range.start
+      const hasRange = Boolean(date_range && (date_range.start || date_range.end));
+
+      // The Events resource supports neither $search nor recurring-series
+      // expansion, so every keyword or date-window search runs through
+      // calendarView (which requires an explicit window) and filters keyword
+      // matches by subject/preview/location in memory.
+      if (query || hasRange) {
+        const now = Date.now();
+        // When a range is given, fill the missing side as now .. now+30d.
+        // For a bare keyword search, widen the default window to include the
+        // recent past so existing events are found.
+        const defaultStart = hasRange ? now : now - 30 * 24 * 3600 * 1000;
+        const defaultEnd = now + (hasRange ? 30 : 90) * 24 * 3600 * 1000;
+        const start = date_range?.start
           ? new Date(date_range.start).toISOString()
-          : new Date().toISOString();
-        const end = date_range.end
+          : new Date(defaultStart).toISOString();
+        const end = date_range?.end
           ? new Date(date_range.end).toISOString()
-          : new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString();
-        // calendarView expands recurring series across the window but does NOT
-        // support $search, so when a keyword is also supplied we over-fetch and
-        // filter by subject/preview/location in memory.
+          : new Date(defaultEnd).toISOString();
         const result = await graphGet(token, "/me/calendarView", {
           startDateTime: start,
           endDateTime: end,
@@ -123,14 +133,6 @@ export function registerCalendarTools(server, token) {
             .slice(0, 25);
         }
         return result;
-      }
-      if (query) {
-        return graphGet(
-          token,
-          "/me/events",
-          { $search: searchPhrase(query), $top: 25, $select: EVENT_SELECT },
-          { ConsistencyLevel: "eventual" },
-        );
       }
       return graphGet(token, "/me/events", {
         $top: 25,
@@ -222,10 +224,15 @@ export function registerCalendarTools(server, token) {
         .describe("Send a response to the organizer (default true)."),
     },
     runTool(async ({ event_id, comment, send_response }) => {
-      await graphPost(token, `/me/events/${odataString(event_id)}/accept`, {
-        comment: comment || "",
-        sendResponse: send_response ?? true,
-      });
+      // Graph rejects a non-null comment when sendResponse is false, so only
+      // include the comment when one was actually provided.
+      const payload = { sendResponse: send_response ?? true };
+      if (comment) payload.comment = comment;
+      await graphPost(
+        token,
+        `/me/events/${odataString(event_id)}/accept`,
+        payload,
+      );
       return { status: "accepted", event_id };
     }),
   );
@@ -242,10 +249,15 @@ export function registerCalendarTools(server, token) {
         .describe("Send a response to the organizer (default true)."),
     },
     runTool(async ({ event_id, comment, send_response }) => {
-      await graphPost(token, `/me/events/${odataString(event_id)}/decline`, {
-        comment: comment || "",
-        sendResponse: send_response ?? true,
-      });
+      // Graph rejects a non-null comment when sendResponse is false, so only
+      // include the comment when one was actually provided.
+      const payload = { sendResponse: send_response ?? true };
+      if (comment) payload.comment = comment;
+      await graphPost(
+        token,
+        `/me/events/${odataString(event_id)}/decline`,
+        payload,
+      );
       return { status: "declined", event_id };
     }),
   );

--- a/m365-mcp/src/tools/calendar.js
+++ b/m365-mcp/src/tools/calendar.js
@@ -56,7 +56,9 @@ function buildEvent({ subject, body, start, end, location, attendees, is_online_
 export function registerCalendarTools(server, token) {
   server.tool(
     "list_events",
-    "List the signed-in user's upcoming calendar events, ordered by start time.",
+    "List the signed-in user's calendar events, ordered by start time " +
+      "(includes past events). To scope to a date window or only future " +
+      "events, use search_events with a date_range.",
     {
       calendar_id: z
         .string()
@@ -90,7 +92,7 @@ export function registerCalendarTools(server, token) {
       query: z.string().optional().describe("Free-text search over events."),
       date_range: dateRangeSchema,
     },
-    runTool(({ query, date_range }) => {
+    runTool(async ({ query, date_range }) => {
       if (date_range && (date_range.start || date_range.end)) {
         const start = date_range.start
           ? new Date(date_range.start).toISOString()
@@ -98,22 +100,29 @@ export function registerCalendarTools(server, token) {
         const end = date_range.end
           ? new Date(date_range.end).toISOString()
           : new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString();
-        const params = {
+        // calendarView expands recurring series across the window but does NOT
+        // support $search, so when a keyword is also supplied we over-fetch and
+        // filter by subject/preview/location in memory.
+        const result = await graphGet(token, "/me/calendarView", {
           startDateTime: start,
           endDateTime: end,
-          $top: 25,
+          $top: query ? 100 : 25,
           $orderby: "start/dateTime",
           $select: EVENT_SELECT,
-        };
-        if (query) {
-          return graphGet(
-            token,
-            "/me/calendarView",
-            { ...params, $search: searchPhrase(query) },
-            { ConsistencyLevel: "eventual" },
-          );
+        });
+        if (query && Array.isArray(result?.value)) {
+          const needle = query.toLowerCase();
+          result.value = result.value
+            .filter((e) =>
+              [e.subject, e.bodyPreview, e.location?.displayName].some(
+                (field) =>
+                  typeof field === "string" &&
+                  field.toLowerCase().includes(needle),
+              ),
+            )
+            .slice(0, 25);
         }
-        return graphGet(token, "/me/calendarView", params);
+        return result;
       }
       if (query) {
         return graphGet(

--- a/m365-mcp/src/tools/calendar.js
+++ b/m365-mcp/src/tools/calendar.js
@@ -1,0 +1,282 @@
+/**
+ * Outlook Calendar tools (Microsoft Graph /me/events, /me/calendar*).
+ */
+
+import { z } from "zod";
+import {
+  graphGet,
+  graphPost,
+  graphPatch,
+  graphDelete,
+} from "../graph.js";
+import { runTool, dateRangeSchema, odataString, searchPhrase } from "./util.js";
+
+const EVENT_SELECT =
+  "id,subject,organizer,start,end,location,bodyPreview,webLink,attendees,isAllDay,isCancelled,onlineMeeting";
+
+const dateTimeSchema = z
+  .object({
+    dateTime: z.string().describe("Local date/time, ISO 8601."),
+    timeZone: z
+      .string()
+      .optional()
+      .describe("IANA/Windows time zone. Defaults to UTC."),
+  })
+  .describe("A Graph dateTimeTimeZone value.");
+
+/** Normalize a {dateTime,timeZone} input, defaulting the zone to UTC. */
+function dateTime(value) {
+  if (!value) return undefined;
+  return { dateTime: value.dateTime, timeZone: value.timeZone || "UTC" };
+}
+
+/** Build a Graph event resource from common create/update fields. */
+function buildEvent({ subject, body, start, end, location, attendees, is_online_meeting }) {
+  const event = {};
+  if (subject !== undefined) event.subject = subject;
+  if (body !== undefined) {
+    event.body = { contentType: body.contentType || "text", content: body.content };
+  }
+  if (start) event.start = dateTime(start);
+  if (end) event.end = dateTime(end);
+  if (location !== undefined) event.location = { displayName: location };
+  if (attendees) {
+    event.attendees = attendees.map((address) => ({
+      emailAddress: { address },
+      type: "required",
+    }));
+  }
+  if (is_online_meeting !== undefined) {
+    event.isOnlineMeeting = is_online_meeting;
+    if (is_online_meeting) event.onlineMeetingProvider = "teamsForBusiness";
+  }
+  return event;
+}
+
+export function registerCalendarTools(server, token) {
+  server.tool(
+    "list_events",
+    "List the signed-in user's upcoming calendar events, ordered by start time.",
+    {
+      calendar_id: z
+        .string()
+        .optional()
+        .describe("Specific calendar id. Defaults to the primary calendar."),
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe("Max events to return (default 25)."),
+    },
+    runTool(({ calendar_id, top }) => {
+      const base = calendar_id
+        ? `/me/calendars/${odataString(calendar_id)}/events`
+        : "/me/events";
+      return graphGet(token, base, {
+        $top: top ?? 25,
+        $orderby: "start/dateTime",
+        $select: EVENT_SELECT,
+      });
+    }),
+  );
+
+  server.tool(
+    "search_events",
+    "Search calendar events by keyword and/or date range. When a date range " +
+      "is supplied, recurring events are expanded via calendarView.",
+    {
+      query: z.string().optional().describe("Free-text search over events."),
+      date_range: dateRangeSchema,
+    },
+    runTool(({ query, date_range }) => {
+      if (date_range && (date_range.start || date_range.end)) {
+        const start = date_range.start
+          ? new Date(date_range.start).toISOString()
+          : new Date().toISOString();
+        const end = date_range.end
+          ? new Date(date_range.end).toISOString()
+          : new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString();
+        const params = {
+          startDateTime: start,
+          endDateTime: end,
+          $top: 25,
+          $orderby: "start/dateTime",
+          $select: EVENT_SELECT,
+        };
+        if (query) {
+          return graphGet(
+            token,
+            "/me/calendarView",
+            { ...params, $search: searchPhrase(query) },
+            { ConsistencyLevel: "eventual" },
+          );
+        }
+        return graphGet(token, "/me/calendarView", params);
+      }
+      if (query) {
+        return graphGet(
+          token,
+          "/me/events",
+          { $search: searchPhrase(query), $top: 25, $select: EVENT_SELECT },
+          { ConsistencyLevel: "eventual" },
+        );
+      }
+      return graphGet(token, "/me/events", {
+        $top: 25,
+        $orderby: "start/dateTime",
+        $select: EVENT_SELECT,
+      });
+    }),
+  );
+
+  server.tool(
+    "get_event",
+    "Get full details for a calendar event by id.",
+    { event_id: z.string().describe("The event id.") },
+    runTool(({ event_id }) =>
+      graphGet(token, `/me/events/${odataString(event_id)}`, {
+        $select: EVENT_SELECT + ",body",
+      }),
+    ),
+  );
+
+  server.tool(
+    "create_event",
+    "Create a new calendar event, optionally as a Teams online meeting.",
+    {
+      subject: z.string().describe("Event subject/title."),
+      start: dateTimeSchema,
+      end: dateTimeSchema,
+      body: z
+        .object({
+          content: z.string(),
+          contentType: z.enum(["text", "html"]).optional(),
+        })
+        .optional()
+        .describe("Event description/body."),
+      location: z.string().optional().describe("Location display name."),
+      attendees: z
+        .array(z.string())
+        .optional()
+        .describe("Attendee email addresses."),
+      is_online_meeting: z
+        .boolean()
+        .optional()
+        .describe("Create a Teams online meeting for this event."),
+    },
+    runTool((args) => graphPost(token, "/me/events", buildEvent(args))),
+  );
+
+  server.tool(
+    "update_event",
+    "Update fields on an existing calendar event.",
+    {
+      event_id: z.string().describe("Id of the event to update."),
+      subject: z.string().optional(),
+      start: dateTimeSchema.optional(),
+      end: dateTimeSchema.optional(),
+      body: z
+        .object({
+          content: z.string(),
+          contentType: z.enum(["text", "html"]).optional(),
+        })
+        .optional(),
+      location: z.string().optional(),
+      attendees: z.array(z.string()).optional(),
+    },
+    runTool(({ event_id, ...rest }) =>
+      graphPatch(token, `/me/events/${odataString(event_id)}`, buildEvent(rest)),
+    ),
+  );
+
+  server.tool(
+    "delete_event",
+    "Delete a calendar event by id.",
+    { event_id: z.string().describe("Id of the event to delete.") },
+    runTool(async ({ event_id }) => {
+      await graphDelete(token, `/me/events/${odataString(event_id)}`);
+      return { status: "deleted", event_id };
+    }),
+  );
+
+  server.tool(
+    "accept_event",
+    "Accept a meeting invitation.",
+    {
+      event_id: z.string().describe("Id of the event/invitation."),
+      comment: z.string().optional().describe("Optional response comment."),
+      send_response: z
+        .boolean()
+        .optional()
+        .describe("Send a response to the organizer (default true)."),
+    },
+    runTool(async ({ event_id, comment, send_response }) => {
+      await graphPost(token, `/me/events/${odataString(event_id)}/accept`, {
+        comment: comment || "",
+        sendResponse: send_response ?? true,
+      });
+      return { status: "accepted", event_id };
+    }),
+  );
+
+  server.tool(
+    "decline_event",
+    "Decline a meeting invitation.",
+    {
+      event_id: z.string().describe("Id of the event/invitation."),
+      comment: z.string().optional().describe("Optional response comment."),
+      send_response: z
+        .boolean()
+        .optional()
+        .describe("Send a response to the organizer (default true)."),
+    },
+    runTool(async ({ event_id, comment, send_response }) => {
+      await graphPost(token, `/me/events/${odataString(event_id)}/decline`, {
+        comment: comment || "",
+        sendResponse: send_response ?? true,
+      });
+      return { status: "declined", event_id };
+    }),
+  );
+
+  server.tool(
+    "find_free_slots",
+    "Look up free/busy availability for one or more people over a time window " +
+      "using the calendar getSchedule API.",
+    {
+      schedules: z
+        .array(z.string())
+        .describe("Email addresses to check availability for."),
+      start: dateTimeSchema,
+      end: dateTimeSchema,
+      interval_minutes: z
+        .number()
+        .int()
+        .min(5)
+        .max(1440)
+        .optional()
+        .describe("Availability slot granularity in minutes (default 30)."),
+    },
+    runTool(({ schedules, start, end, interval_minutes }) =>
+      graphPost(token, "/me/calendar/getSchedule", {
+        schedules,
+        startTime: dateTime(start),
+        endTime: dateTime(end),
+        availabilityViewInterval: interval_minutes ?? 30,
+      }),
+    ),
+  );
+
+  server.tool(
+    "list_calendars",
+    "List all calendars owned by or shared with the signed-in user.",
+    {},
+    runTool(() =>
+      graphGet(token, "/me/calendars", {
+        $select: "id,name,owner,canEdit,canShare,isDefaultCalendar,color",
+      }),
+    ),
+  );
+}

--- a/m365-mcp/src/tools/index.js
+++ b/m365-mcp/src/tools/index.js
@@ -1,0 +1,20 @@
+/**
+ * Aggregates all Microsoft 365 tool modules onto an McpServer instance.
+ *
+ * Every tool closes over the caller's bearer `token` so each Graph call runs
+ * on behalf of the requesting user.
+ */
+
+import { registerMailTools } from "./mail.js";
+import { registerCalendarTools } from "./calendar.js";
+import { registerTeamsTools } from "./teams.js";
+import { registerOneDriveTools } from "./onedrive.js";
+import { registerSharePointTools } from "./sharepoint.js";
+
+export function registerTools(server, token) {
+  registerMailTools(server, token);
+  registerCalendarTools(server, token);
+  registerTeamsTools(server, token);
+  registerOneDriveTools(server, token);
+  registerSharePointTools(server, token);
+}

--- a/m365-mcp/src/tools/mail.js
+++ b/m365-mcp/src/tools/mail.js
@@ -1,0 +1,246 @@
+/**
+ * Outlook Mail tools (Microsoft Graph /me/messages, /me/mailFolders).
+ */
+
+import { z } from "zod";
+import {
+  graphGet,
+  graphPost,
+  graphPatch,
+  graphDelete,
+} from "../graph.js";
+import {
+  runTool,
+  dateRangeSchema,
+  dateRangeKql,
+  recipientsSchema,
+  bodySchema,
+  toRecipients,
+  odataString,
+  searchPhrase,
+} from "./util.js";
+
+const MESSAGE_SELECT =
+  "id,subject,from,toRecipients,receivedDateTime,sentDateTime,bodyPreview,webLink,isRead,hasAttachments,importance";
+
+/** Build a Graph message resource from common draft/send fields. */
+function buildMessage({ subject, body, to, cc, bcc }) {
+  const message = {};
+  if (subject !== undefined) message.subject = subject;
+  if (body !== undefined) {
+    message.body = {
+      contentType: body.contentType || "text",
+      content: body.content,
+    };
+  }
+  if (to) message.toRecipients = toRecipients(to);
+  if (cc) message.ccRecipients = toRecipients(cc);
+  if (bcc) message.bccRecipients = toRecipients(bcc);
+  return message;
+}
+
+export function registerMailTools(server, token) {
+  server.tool(
+    "list_emails",
+    "List emails from the signed-in user's mailbox, newest first. Optionally " +
+      "scope to a folder and filter by read state.",
+    {
+      folder_id: z
+        .string()
+        .optional()
+        .describe(
+          "Mail folder id or well-known name (e.g. inbox, sentitems, drafts).",
+        ),
+      unread_only: z
+        .boolean()
+        .optional()
+        .describe("If true, only return unread messages."),
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe("Max messages to return (default 25)."),
+    },
+    runTool(({ folder_id, unread_only, top }) => {
+      const base = folder_id
+        ? `/me/mailFolders/${odataString(folder_id)}/messages`
+        : "/me/messages";
+      return graphGet(token, base, {
+        $top: top ?? 25,
+        $orderby: "receivedDateTime desc",
+        $select: MESSAGE_SELECT,
+        $filter: unread_only ? "isRead eq false" : undefined,
+      });
+    }),
+  );
+
+  server.tool(
+    "search_emails",
+    "Search the mailbox via Microsoft Graph KQL. Supports a free-text query, " +
+      "a sender filter, and a received-date range.",
+    {
+      query: z.string().describe("Free-text search over subject and body."),
+      from: z
+        .string()
+        .optional()
+        .describe("Filter by sender email address or name."),
+      date_range: dateRangeSchema,
+    },
+    runTool(({ query, from, date_range }) => {
+      const terms = [query];
+      if (from) terms.push(`from:${from}`);
+      const dates = dateRangeKql("received", date_range);
+      if (dates) terms.push(dates);
+      const kql = terms.filter(Boolean).join(" AND ");
+      return graphGet(
+        token,
+        "/me/messages",
+        { $search: searchPhrase(kql), $top: 25, $select: MESSAGE_SELECT },
+        { ConsistencyLevel: "eventual" },
+      );
+    }),
+  );
+
+  server.tool(
+    "get_email",
+    "Get a single email by id, including its full body.",
+    {
+      message_id: z.string().describe("The message id."),
+    },
+    runTool(({ message_id }) =>
+      graphGet(token, `/me/messages/${odataString(message_id)}`, {
+        $select: MESSAGE_SELECT + ",body,ccRecipients,bccRecipients",
+      }),
+    ),
+  );
+
+  server.tool(
+    "send_email",
+    "Send a new email immediately from the signed-in user's mailbox.",
+    {
+      to: recipientsSchema,
+      subject: z.string().describe("Email subject line."),
+      body: bodySchema,
+      cc: z.array(z.string()).optional().describe("CC recipients."),
+      bcc: z.array(z.string()).optional().describe("BCC recipients."),
+      save_to_sent: z
+        .boolean()
+        .optional()
+        .describe("Save a copy to Sent Items (default true)."),
+    },
+    runTool(async ({ to, subject, body, cc, bcc, save_to_sent }) => {
+      await graphPost(token, "/me/sendMail", {
+        message: buildMessage({ subject, body, to, cc, bcc }),
+        saveToSentItems: save_to_sent ?? true,
+      });
+      return { status: "sent", to, subject };
+    }),
+  );
+
+  server.tool(
+    "reply_email",
+    "Reply (or reply-all) to an existing email thread.",
+    {
+      message_id: z.string().describe("Id of the message to reply to."),
+      comment: z.string().describe("Reply text to prepend to the thread."),
+      reply_all: z
+        .boolean()
+        .optional()
+        .describe("If true, reply to all recipients (default false)."),
+    },
+    runTool(async ({ message_id, comment, reply_all }) => {
+      const action = reply_all ? "replyAll" : "reply";
+      await graphPost(
+        token,
+        `/me/messages/${odataString(message_id)}/${action}`,
+        { comment },
+      );
+      return { status: "sent", action, message_id };
+    }),
+  );
+
+  server.tool(
+    "create_draft",
+    "Create a draft email without sending it.",
+    {
+      to: z.array(z.string()).optional().describe("Recipient addresses."),
+      subject: z.string().optional().describe("Email subject line."),
+      body: bodySchema.optional(),
+      cc: z.array(z.string()).optional().describe("CC recipients."),
+      bcc: z.array(z.string()).optional().describe("BCC recipients."),
+    },
+    runTool(({ to, subject, body, cc, bcc }) =>
+      graphPost(token, "/me/messages", buildMessage({ subject, body, to, cc, bcc })),
+    ),
+  );
+
+  server.tool(
+    "update_draft",
+    "Update fields on an existing draft email.",
+    {
+      message_id: z.string().describe("Id of the draft message to update."),
+      to: z.array(z.string()).optional().describe("Replacement recipients."),
+      subject: z.string().optional().describe("New subject line."),
+      body: bodySchema.optional(),
+      cc: z.array(z.string()).optional().describe("Replacement CC recipients."),
+      bcc: z.array(z.string()).optional().describe("Replacement BCC recipients."),
+    },
+    runTool(({ message_id, to, subject, body, cc, bcc }) =>
+      graphPatch(
+        token,
+        `/me/messages/${odataString(message_id)}`,
+        buildMessage({ subject, body, to, cc, bcc }),
+      ),
+    ),
+  );
+
+  server.tool(
+    "delete_email",
+    "Delete an email (moves it to Deleted Items).",
+    {
+      message_id: z.string().describe("Id of the message to delete."),
+    },
+    runTool(async ({ message_id }) => {
+      await graphDelete(token, `/me/messages/${odataString(message_id)}`);
+      return { status: "deleted", message_id };
+    }),
+  );
+
+  server.tool(
+    "list_folders",
+    "List the signed-in user's mail folders.",
+    {
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe("Max folders to return (default 50)."),
+    },
+    runTool(({ top }) =>
+      graphGet(token, "/me/mailFolders", {
+        $top: top ?? 50,
+        $select: "id,displayName,parentFolderId,unreadItemCount,totalItemCount",
+      }),
+    ),
+  );
+
+  server.tool(
+    "move_email",
+    "Move an email to a different mail folder.",
+    {
+      message_id: z.string().describe("Id of the message to move."),
+      destination_folder_id: z
+        .string()
+        .describe("Target folder id or well-known name (e.g. archive)."),
+    },
+    runTool(({ message_id, destination_folder_id }) =>
+      graphPost(token, `/me/messages/${odataString(message_id)}/move`, {
+        destinationId: destination_folder_id,
+      }),
+    ),
+  );
+}

--- a/m365-mcp/src/tools/mail.js
+++ b/m365-mcp/src/tools/mail.js
@@ -89,15 +89,19 @@ export function registerMailTools(server, token) {
       date_range: dateRangeSchema,
     },
     runTool(({ query, from, date_range }) => {
-      const terms = [query];
-      if (from) terms.push(`from:${from}`);
+      // $search takes a KQL expression. Quote only the free-text query as a
+      // phrase; leave the boolean operator and property restrictions (from:,
+      // received>=/<=) unquoted so Graph parses them as structured KQL instead
+      // of matching the whole string as one literal phrase.
+      const parts = [searchPhrase(query)];
+      if (from) parts.push(`from:${from}`);
       const dates = dateRangeKql("received", date_range);
-      if (dates) terms.push(dates);
-      const kql = terms.filter(Boolean).join(" AND ");
+      if (dates) parts.push(dates);
+      const kql = parts.join(" AND ");
       return graphGet(
         token,
         "/me/messages",
-        { $search: searchPhrase(kql), $top: 25, $select: MESSAGE_SELECT },
+        { $search: kql, $top: 25, $select: MESSAGE_SELECT },
         { ConsistencyLevel: "eventual" },
       );
     }),

--- a/m365-mcp/src/tools/onedrive.js
+++ b/m365-mcp/src/tools/onedrive.js
@@ -1,0 +1,172 @@
+/**
+ * OneDrive tools (Microsoft Graph /me/drive).
+ */
+
+import { z } from "zod";
+import {
+  graphGet,
+  graphPost,
+  graphPatch,
+  graphDelete,
+  graphUpload,
+  graphDownload,
+} from "../graph.js";
+import { runTool, odataString } from "./util.js";
+
+const ITEM_SELECT =
+  "id,name,webUrl,size,lastModifiedDateTime,createdDateTime,file,folder,parentReference";
+
+/** Resolve a drive-item reference (id or path) to a Graph addressing segment. */
+function itemRef(id) {
+  return `/me/drive/items/${odataString(id)}`;
+}
+
+export function registerOneDriveTools(server, token) {
+  server.tool(
+    "list_files",
+    "List files and folders within a OneDrive folder (the root by default).",
+    {
+      folder_id: z
+        .string()
+        .optional()
+        .describe("Folder item id. Omit to list the drive root."),
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(200)
+        .optional()
+        .describe("Max items to return (default 50)."),
+    },
+    runTool(({ folder_id, top }) => {
+      const base = folder_id
+        ? `${itemRef(folder_id)}/children`
+        : "/me/drive/root/children";
+      return graphGet(token, base, { $top: top ?? 50, $select: ITEM_SELECT });
+    }),
+  );
+
+  server.tool(
+    "search_files",
+    "Search files in the signed-in user's OneDrive by name or content.",
+    { query: z.string().describe("Search term for file names and content.") },
+    runTool(({ query }) =>
+      graphGet(token, `/me/drive/root/search(q='${odataString(query)}')`, {
+        $top: 25,
+        $select: ITEM_SELECT,
+      }),
+    ),
+  );
+
+  server.tool(
+    "get_file",
+    "Get metadata for a OneDrive file or folder by id.",
+    { item_id: z.string().describe("The drive item id.") },
+    runTool(({ item_id }) =>
+      graphGet(token, itemRef(item_id), { $select: ITEM_SELECT }),
+    ),
+  );
+
+  server.tool(
+    "download_file",
+    "Download a OneDrive file's content, returned base64-encoded.",
+    { item_id: z.string().describe("The drive item id to download.") },
+    runTool(({ item_id }) => graphDownload(token, `${itemRef(item_id)}/content`)),
+  );
+
+  server.tool(
+    "upload_file",
+    "Upload a small file (< 4 MB) to OneDrive. Content must be base64-encoded.",
+    {
+      name: z.string().describe("File name, including extension."),
+      content_base64: z.string().describe("Base64-encoded file content."),
+      parent_id: z
+        .string()
+        .optional()
+        .describe("Parent folder id. Omit to upload to the drive root."),
+      content_type: z
+        .string()
+        .optional()
+        .describe("MIME type (default application/octet-stream)."),
+    },
+    runTool(({ name, content_base64, parent_id, content_type }) => {
+      const bytes = Buffer.from(content_base64, "base64");
+      const safeName = odataString(name);
+      const path = parent_id
+        ? `${itemRef(parent_id)}:/${safeName}:/content`
+        : `/me/drive/root:/${safeName}:/content`;
+      return graphUpload(token, path, bytes, content_type);
+    }),
+  );
+
+  server.tool(
+    "create_folder",
+    "Create a new folder in OneDrive.",
+    {
+      name: z.string().describe("Folder name."),
+      parent_id: z
+        .string()
+        .optional()
+        .describe("Parent folder id. Omit to create under the drive root."),
+    },
+    runTool(({ name, parent_id }) => {
+      const base = parent_id
+        ? `${itemRef(parent_id)}/children`
+        : "/me/drive/root/children";
+      return graphPost(token, base, {
+        name,
+        folder: {},
+        "@microsoft.graph.conflictBehavior": "rename",
+      });
+    }),
+  );
+
+  server.tool(
+    "delete_file",
+    "Delete a OneDrive file or folder by id.",
+    { item_id: z.string().describe("The drive item id to delete.") },
+    runTool(async ({ item_id }) => {
+      await graphDelete(token, itemRef(item_id));
+      return { status: "deleted", item_id };
+    }),
+  );
+
+  server.tool(
+    "move_file",
+    "Move (and optionally rename) a OneDrive file or folder.",
+    {
+      item_id: z.string().describe("The drive item id to move."),
+      destination_parent_id: z
+        .string()
+        .describe("Id of the destination folder."),
+      new_name: z.string().optional().describe("Optional new name."),
+    },
+    runTool(({ item_id, destination_parent_id, new_name }) => {
+      const body = { parentReference: { id: destination_parent_id } };
+      if (new_name) body.name = new_name;
+      return graphPatch(token, itemRef(item_id), body);
+    }),
+  );
+
+  server.tool(
+    "share_file",
+    "Create a sharing link for a OneDrive file or folder.",
+    {
+      item_id: z.string().describe("The drive item id to share."),
+      link_type: z
+        .enum(["view", "edit", "embed"])
+        .optional()
+        .describe("Permission level of the link (default 'view')."),
+      scope: z
+        .enum(["anonymous", "organization"])
+        .optional()
+        .describe("Link audience (default 'organization')."),
+    },
+    runTool(({ item_id, link_type, scope }) =>
+      graphPost(token, `${itemRef(item_id)}/createLink`, {
+        type: link_type || "view",
+        scope: scope || "organization",
+      }),
+    ),
+  );
+}

--- a/m365-mcp/src/tools/onedrive.js
+++ b/m365-mcp/src/tools/onedrive.js
@@ -51,10 +51,11 @@ export function registerOneDriveTools(server, token) {
     "Search files in the signed-in user's OneDrive by name or content.",
     { query: z.string().describe("Search term for file names and content.") },
     runTool(({ query }) =>
-      // odataString does both layers correctly: it doubles single quotes for
-      // the OData string literal, then percent-encodes for the URL path (which
-      // Graph decodes before OData parsing). Don't drop the encoding — raw '#',
-      // '?' or '%' in the query would otherwise corrupt the request URL.
+      // q is an OData string literal embedded in the URL path, so odataString
+      // applies the two escaping layers it needs: it doubles any embedded
+      // single quotes so a quote in the query can't terminate the literal
+      // early, then percent-encodes the value so reserved characters ('#',
+      // '?', '%', spaces) keep the request URL well-formed.
       graphGet(token, `/me/drive/root/search(q='${odataString(query)}')`, {
         $top: 25,
         $select: ITEM_SELECT,

--- a/m365-mcp/src/tools/onedrive.js
+++ b/m365-mcp/src/tools/onedrive.js
@@ -51,6 +51,10 @@ export function registerOneDriveTools(server, token) {
     "Search files in the signed-in user's OneDrive by name or content.",
     { query: z.string().describe("Search term for file names and content.") },
     runTool(({ query }) =>
+      // odataString does both layers correctly: it doubles single quotes for
+      // the OData string literal, then percent-encodes for the URL path (which
+      // Graph decodes before OData parsing). Don't drop the encoding — raw '#',
+      // '?' or '%' in the query would otherwise corrupt the request URL.
       graphGet(token, `/me/drive/root/search(q='${odataString(query)}')`, {
         $top: 25,
         $select: ITEM_SELECT,

--- a/m365-mcp/src/tools/sharepoint.js
+++ b/m365-mcp/src/tools/sharepoint.js
@@ -10,7 +10,7 @@ import {
   graphUpload,
   microsoftSearch,
 } from "../graph.js";
-import { runTool, odataString } from "./util.js";
+import { runTool, odataString, siteId } from "./util.js";
 
 export function registerSharePointTools(server, token) {
   server.tool(
@@ -51,7 +51,7 @@ export function registerSharePointTools(server, token) {
         ),
     },
     runTool(({ site_id }) =>
-      graphGet(token, `/sites/${odataString(site_id)}`),
+      graphGet(token, `/sites/${siteId(site_id)}`),
     ),
   );
 
@@ -60,7 +60,7 @@ export function registerSharePointTools(server, token) {
     "List the document libraries (drives) in a SharePoint site.",
     { site_id: z.string().describe("The SharePoint site id.") },
     runTool(({ site_id }) =>
-      graphGet(token, `/sites/${odataString(site_id)}/drives`, {
+      graphGet(token, `/sites/${siteId(site_id)}/drives`, {
         $select: "id,name,webUrl,driveType,quota",
       }),
     ),
@@ -83,7 +83,7 @@ export function registerSharePointTools(server, token) {
     runTool(({ site_id, list_id, top }) =>
       graphGet(
         token,
-        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items`,
+        `/sites/${siteId(site_id)}/lists/${odataString(list_id)}/items`,
         { $expand: "fields", $top: top ?? 50 },
       ),
     ),
@@ -100,7 +100,7 @@ export function registerSharePointTools(server, token) {
     runTool(({ site_id, list_id, item_id }) =>
       graphGet(
         token,
-        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items/${odataString(item_id)}`,
+        `/sites/${siteId(site_id)}/lists/${odataString(list_id)}/items/${odataString(item_id)}`,
         { $expand: "fields" },
       ),
     ),
@@ -119,7 +119,7 @@ export function registerSharePointTools(server, token) {
     runTool(({ site_id, list_id, fields }) =>
       graphPost(
         token,
-        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items`,
+        `/sites/${siteId(site_id)}/lists/${odataString(list_id)}/items`,
         { fields },
       ),
     ),
@@ -139,7 +139,7 @@ export function registerSharePointTools(server, token) {
     runTool(({ site_id, list_id, item_id, fields }) =>
       graphPatch(
         token,
-        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items/${odataString(item_id)}/fields`,
+        `/sites/${siteId(site_id)}/lists/${odataString(list_id)}/items/${odataString(item_id)}/fields`,
         fields,
       ),
     ),
@@ -170,7 +170,7 @@ export function registerSharePointTools(server, token) {
       const bytes = Buffer.from(content_base64, "base64");
       const driveBase = drive_id
         ? `/drives/${odataString(drive_id)}`
-        : `/sites/${odataString(site_id)}/drive`;
+        : `/sites/${siteId(site_id)}/drive`;
       const prefix = folder_path
         ? folder_path
             .split("/")

--- a/m365-mcp/src/tools/sharepoint.js
+++ b/m365-mcp/src/tools/sharepoint.js
@@ -1,0 +1,185 @@
+/**
+ * SharePoint tools (Microsoft Graph /sites + Microsoft Search API).
+ */
+
+import { z } from "zod";
+import {
+  graphGet,
+  graphPost,
+  graphPatch,
+  graphUpload,
+  microsoftSearch,
+} from "../graph.js";
+import { runTool, odataString } from "./util.js";
+
+export function registerSharePointTools(server, token) {
+  server.tool(
+    "search_sharepoint",
+    "Full-text search across SharePoint sites, lists, and documents in the " +
+      "tenant via the Microsoft Search API.",
+    { query: z.string().describe("Search term for SharePoint content.") },
+    runTool(({ query }) =>
+      microsoftSearch(token, ["driveItem", "listItem", "site"], query),
+    ),
+  );
+
+  server.tool(
+    "list_sites",
+    "List/search SharePoint sites in the tenant.",
+    {
+      query: z
+        .string()
+        .optional()
+        .describe("Keyword to match site names. Omit to list all sites."),
+    },
+    runTool(({ query }) =>
+      graphGet(token, "/sites", {
+        search: query ?? "*",
+        $select: "id,name,displayName,webUrl,description",
+      }),
+    ),
+  );
+
+  server.tool(
+    "get_site",
+    "Get details for a SharePoint site by id or hostname:path.",
+    {
+      site_id: z
+        .string()
+        .describe(
+          "Site id, or hostname + path (e.g. contoso.sharepoint.com:/sites/Team).",
+        ),
+    },
+    runTool(({ site_id }) =>
+      graphGet(token, `/sites/${odataString(site_id)}`),
+    ),
+  );
+
+  server.tool(
+    "list_libraries",
+    "List the document libraries (drives) in a SharePoint site.",
+    { site_id: z.string().describe("The SharePoint site id.") },
+    runTool(({ site_id }) =>
+      graphGet(token, `/sites/${odataString(site_id)}/drives`, {
+        $select: "id,name,webUrl,driveType,quota",
+      }),
+    ),
+  );
+
+  server.tool(
+    "list_items",
+    "List items in a SharePoint list, expanding their field values.",
+    {
+      site_id: z.string().describe("The SharePoint site id."),
+      list_id: z.string().describe("The list id."),
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(200)
+        .optional()
+        .describe("Max items to return (default 50)."),
+    },
+    runTool(({ site_id, list_id, top }) =>
+      graphGet(
+        token,
+        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items`,
+        { $expand: "fields", $top: top ?? 50 },
+      ),
+    ),
+  );
+
+  server.tool(
+    "get_item",
+    "Get a single SharePoint list item, including its field values.",
+    {
+      site_id: z.string().describe("The SharePoint site id."),
+      list_id: z.string().describe("The list id."),
+      item_id: z.string().describe("The list item id."),
+    },
+    runTool(({ site_id, list_id, item_id }) =>
+      graphGet(
+        token,
+        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items/${odataString(item_id)}`,
+        { $expand: "fields" },
+      ),
+    ),
+  );
+
+  server.tool(
+    "create_item",
+    "Create a new item in a SharePoint list.",
+    {
+      site_id: z.string().describe("The SharePoint site id."),
+      list_id: z.string().describe("The list id."),
+      fields: z
+        .record(z.any())
+        .describe("Object of column internal-name -> value pairs."),
+    },
+    runTool(({ site_id, list_id, fields }) =>
+      graphPost(
+        token,
+        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items`,
+        { fields },
+      ),
+    ),
+  );
+
+  server.tool(
+    "update_item",
+    "Update field values on an existing SharePoint list item.",
+    {
+      site_id: z.string().describe("The SharePoint site id."),
+      list_id: z.string().describe("The list id."),
+      item_id: z.string().describe("The list item id."),
+      fields: z
+        .record(z.any())
+        .describe("Object of column internal-name -> new value pairs."),
+    },
+    runTool(({ site_id, list_id, item_id, fields }) =>
+      graphPatch(
+        token,
+        `/sites/${odataString(site_id)}/lists/${odataString(list_id)}/items/${odataString(item_id)}/fields`,
+        fields,
+      ),
+    ),
+  );
+
+  server.tool(
+    "upload_to_sharepoint",
+    "Upload a small file (< 4 MB) to a SharePoint site's document library. " +
+      "Content must be base64-encoded.",
+    {
+      site_id: z.string().describe("The SharePoint site id."),
+      name: z.string().describe("File name, including extension."),
+      content_base64: z.string().describe("Base64-encoded file content."),
+      folder_path: z
+        .string()
+        .optional()
+        .describe("Folder path within the library (e.g. 'Reports/2024')."),
+      drive_id: z
+        .string()
+        .optional()
+        .describe("Target library/drive id. Defaults to the site's drive."),
+      content_type: z
+        .string()
+        .optional()
+        .describe("MIME type (default application/octet-stream)."),
+    },
+    runTool(({ site_id, name, content_base64, folder_path, drive_id, content_type }) => {
+      const bytes = Buffer.from(content_base64, "base64");
+      const driveBase = drive_id
+        ? `/drives/${odataString(drive_id)}`
+        : `/sites/${odataString(site_id)}/drive`;
+      const prefix = folder_path
+        ? folder_path
+            .split("/")
+            .filter(Boolean)
+            .map(odataString)
+            .join("/") + "/"
+        : "";
+      const path = `${driveBase}/root:/${prefix}${odataString(name)}:/content`;
+      return graphUpload(token, path, bytes, content_type);
+    }),
+  );
+}

--- a/m365-mcp/src/tools/teams.js
+++ b/m365-mcp/src/tools/teams.js
@@ -1,0 +1,205 @@
+/**
+ * Microsoft Teams tools (Graph /me/chats, /chats, /teams, /me/joinedTeams).
+ */
+
+import { z } from "zod";
+import { graphGet, graphPost, microsoftSearch } from "../graph.js";
+import { runTool, odataString } from "./util.js";
+
+/** Build a Graph chatMessage body resource. */
+function messageBody(content, contentType) {
+  return { body: { contentType: contentType || "text", content } };
+}
+
+export function registerTeamsTools(server, token) {
+  server.tool(
+    "list_chats",
+    "List the signed-in user's Teams chats (1:1, group, and meeting chats).",
+    {
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Max chats to return (default 25)."),
+    },
+    runTool(({ top }) =>
+      graphGet(token, "/me/chats", {
+        $top: top ?? 25,
+        $expand: "members",
+        $orderby: "lastMessagePreview/createdDateTime desc",
+      }),
+    ),
+  );
+
+  server.tool(
+    "search_chat_messages",
+    "Search across the signed-in user's Teams chat messages via the " +
+      "Microsoft Search API.",
+    { query: z.string().describe("Search term for Teams chat messages.") },
+    runTool(({ query }) => microsoftSearch(token, ["chatMessage"], query)),
+  );
+
+  server.tool(
+    "get_chat_messages",
+    "Get recent messages from a specific Teams chat.",
+    {
+      chat_id: z.string().describe("The chat id."),
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Max messages to return (default 25)."),
+    },
+    runTool(({ chat_id, top }) =>
+      graphGet(token, `/me/chats/${odataString(chat_id)}/messages`, {
+        $top: top ?? 25,
+        $orderby: "createdDateTime desc",
+      }),
+    ),
+  );
+
+  server.tool(
+    "send_chat_message",
+    "Post a message to an existing Teams chat.",
+    {
+      chat_id: z.string().describe("The chat id to post to."),
+      content: z.string().describe("Message content."),
+      content_type: z
+        .enum(["text", "html"])
+        .optional()
+        .describe("Content type (default 'text')."),
+    },
+    runTool(({ chat_id, content, content_type }) =>
+      graphPost(
+        token,
+        `/me/chats/${odataString(chat_id)}/messages`,
+        messageBody(content, content_type),
+      ),
+    ),
+  );
+
+  server.tool(
+    "create_chat",
+    "Create a new Teams chat. Provide member email addresses; the signed-in " +
+      "user is added automatically.",
+    {
+      members: z
+        .array(z.string())
+        .describe("Email addresses (UPNs) of members to add."),
+      chat_type: z
+        .enum(["oneOnOne", "group"])
+        .optional()
+        .describe("Chat type. Defaults to 'group' (or 'oneOnOne' for 1 member)."),
+      topic: z
+        .string()
+        .optional()
+        .describe("Topic/title for a group chat."),
+    },
+    runTool(({ members, chat_type, topic }) => {
+      const type = chat_type || (members.length <= 1 ? "oneOnOne" : "group");
+      const body = {
+        chatType: type,
+        members: members.map((upn) => ({
+          "@odata.type": "#microsoft.graph.aadUserConversationMember",
+          roles: ["owner"],
+          "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${upn}')`,
+        })),
+      };
+      if (topic && type === "group") body.topic = topic;
+      return graphPost(token, "/chats", body);
+    }),
+  );
+
+  server.tool(
+    "add_chat_member",
+    "Add a member to an existing Teams group chat.",
+    {
+      chat_id: z.string().describe("The chat id."),
+      user: z.string().describe("Email address (UPN) of the user to add."),
+      share_history: z
+        .boolean()
+        .optional()
+        .describe("Share all prior message history with the new member."),
+    },
+    runTool(({ chat_id, user, share_history }) =>
+      graphPost(token, `/chats/${odataString(chat_id)}/members`, {
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        roles: ["owner"],
+        "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${user}')`,
+        visibleHistoryStartDateTime: share_history
+          ? "0001-01-01T00:00:00Z"
+          : undefined,
+      }),
+    ),
+  );
+
+  server.tool(
+    "list_teams",
+    "List the teams the signed-in user has joined.",
+    {},
+    runTool(() =>
+      graphGet(token, "/me/joinedTeams", {
+        $select: "id,displayName,description,visibility",
+      }),
+    ),
+  );
+
+  server.tool(
+    "list_channels",
+    "List the channels within a team.",
+    { team_id: z.string().describe("The team id.") },
+    runTool(({ team_id }) =>
+      graphGet(token, `/teams/${odataString(team_id)}/channels`, {
+        $select: "id,displayName,description,membershipType,webUrl",
+      }),
+    ),
+  );
+
+  server.tool(
+    "get_channel_messages",
+    "Read recent messages from a team channel.",
+    {
+      team_id: z.string().describe("The team id."),
+      channel_id: z.string().describe("The channel id."),
+      top: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Max messages to return (default 20)."),
+    },
+    runTool(({ team_id, channel_id, top }) =>
+      graphGet(
+        token,
+        `/teams/${odataString(team_id)}/channels/${odataString(channel_id)}/messages`,
+        { $top: top ?? 20 },
+      ),
+    ),
+  );
+
+  server.tool(
+    "post_channel_message",
+    "Post a message to a team channel.",
+    {
+      team_id: z.string().describe("The team id."),
+      channel_id: z.string().describe("The channel id."),
+      content: z.string().describe("Message content."),
+      content_type: z
+        .enum(["text", "html"])
+        .optional()
+        .describe("Content type (default 'text')."),
+    },
+    runTool(({ team_id, channel_id, content, content_type }) =>
+      graphPost(
+        token,
+        `/teams/${odataString(team_id)}/channels/${odataString(channel_id)}/messages`,
+        messageBody(content, content_type),
+      ),
+    ),
+  );
+}

--- a/m365-mcp/src/tools/teams.js
+++ b/m365-mcp/src/tools/teams.js
@@ -4,7 +4,16 @@
 
 import { z } from "zod";
 import { graphGet, graphPost, microsoftSearch } from "../graph.js";
-import { runTool, odataString } from "./util.js";
+import { runTool, odataString, odataLiteral } from "./util.js";
+
+/** Build an aadUserConversationMember bind for a user UPN/id. */
+function memberBind(userIdOrUpn) {
+  return {
+    "@odata.type": "#microsoft.graph.aadUserConversationMember",
+    roles: ["owner"],
+    "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${odataLiteral(userIdOrUpn)}')`,
+  };
+}
 
 /** Build a Graph chatMessage body resource. */
 function messageBody(content, contentType) {
@@ -100,16 +109,21 @@ export function registerTeamsTools(server, token) {
         .optional()
         .describe("Topic/title for a group chat."),
     },
-    runTool(({ members, chat_type, topic }) => {
+    runTool(async ({ members, chat_type, topic }) => {
       const type = chat_type || (members.length <= 1 ? "oneOnOne" : "group");
-      const body = {
-        chatType: type,
-        members: members.map((upn) => ({
-          "@odata.type": "#microsoft.graph.aadUserConversationMember",
-          roles: ["owner"],
-          "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${upn}')`,
-        })),
-      };
+      // Graph requires the caller to be one of the chat members; add them if
+      // the client didn't include their own address.
+      const me = await graphGet(token, "/me", {
+        $select: "id,userPrincipalName",
+      });
+      const upn = me.userPrincipalName || "";
+      const allMembers = members.some(
+        (m) => m.toLowerCase() === upn.toLowerCase(),
+      )
+        ? members
+        : [...members, me.id];
+
+      const body = { chatType: type, members: allMembers.map(memberBind) };
       if (topic && type === "group") body.topic = topic;
       return graphPost(token, "/chats", body);
     }),
@@ -128,9 +142,7 @@ export function registerTeamsTools(server, token) {
     },
     runTool(({ chat_id, user, share_history }) =>
       graphPost(token, `/chats/${odataString(chat_id)}/members`, {
-        "@odata.type": "#microsoft.graph.aadUserConversationMember",
-        roles: ["owner"],
-        "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${user}')`,
+        ...memberBind(user),
         visibleHistoryStartDateTime: share_history
           ? "0001-01-01T00:00:00Z"
           : undefined,

--- a/m365-mcp/src/tools/teams.js
+++ b/m365-mcp/src/tools/teams.js
@@ -27,7 +27,8 @@ export function registerTeamsTools(server, token) {
     runTool(({ top }) =>
       graphGet(token, "/me/chats", {
         $top: top ?? 25,
-        $expand: "members",
+        // Graph requires lastMessagePreview to be expanded when ordering by it.
+        $expand: "members,lastMessagePreview",
         $orderby: "lastMessagePreview/createdDateTime desc",
       }),
     ),

--- a/m365-mcp/src/tools/teams.js
+++ b/m365-mcp/src/tools/teams.js
@@ -112,16 +112,32 @@ export function registerTeamsTools(server, token) {
     runTool(async ({ members, chat_type, topic }) => {
       const type = chat_type || (members.length <= 1 ? "oneOnOne" : "group");
       // Graph requires the caller to be one of the chat members; add them if
-      // the client didn't include their own address.
+      // the client didn't include their own address. The client may identify
+      // the caller by either UPN or Graph object id, so check both — matching
+      // only the UPN would append a duplicate when the caller's id was passed.
       const me = await graphGet(token, "/me", {
         $select: "id,userPrincipalName",
       });
-      const upn = me.userPrincipalName || "";
-      const allMembers = members.some(
-        (m) => m.toLowerCase() === upn.toLowerCase(),
-      )
+      const selfKeys = new Set(
+        [me.userPrincipalName, me.id]
+          .filter(Boolean)
+          .map((v) => v.toLowerCase()),
+      );
+      const allMembers = members.some((m) => selfKeys.has(m.toLowerCase()))
         ? members
         : [...members, me.id];
+
+      // Graph requires a oneOnOne chat to have exactly two members (the caller
+      // plus one other). An empty/self-only members list or three-plus members
+      // would otherwise fail or behave incorrectly at Graph, so reject it early
+      // with a hint to use a group chat instead.
+      if (type === "oneOnOne" && allMembers.length !== 2) {
+        throw new Error(
+          `A oneOnOne chat needs exactly two members (you + one other), but ` +
+            `resolved to ${allMembers.length}. Provide exactly one other ` +
+            `member, or set chat_type to "group".`,
+        );
+      }
 
       const body = { chatType: type, members: allMembers.map(memberBind) };
       if (topic && type === "group") body.topic = topic;

--- a/m365-mcp/src/tools/util.js
+++ b/m365-mcp/src/tools/util.js
@@ -1,0 +1,88 @@
+/**
+ * Shared helpers and zod schemas for the Microsoft 365 tool modules.
+ */
+
+import { z } from "zod";
+import { GraphError } from "../graph.js";
+
+/** Build a successful MCP tool result from data (object -> pretty JSON). */
+export function ok(data) {
+  const text = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+  return { content: [{ type: "text", text }] };
+}
+
+/**
+ * Wrap an async tool handler so Graph/runtime failures become readable MCP
+ * tool errors instead of throwing out of the transport.
+ */
+export function runTool(handler) {
+  return async (args) => {
+    try {
+      return ok(await handler(args ?? {}));
+    } catch (err) {
+      const message =
+        err instanceof GraphError
+          ? `Graph API error (${err.status}): ${err.message}`
+          : `Unexpected error: ${err.message}`;
+      return { isError: true, content: [{ type: "text", text: message }] };
+    }
+  };
+}
+
+/** Encode a value for safe inclusion inside an OData single-quoted literal. */
+export function odataString(value) {
+  return encodeURIComponent(String(value).replace(/'/g, "''"));
+}
+
+/**
+ * Quote a value as a Graph `$search` phrase. The expression is wrapped in
+ * double quotes, so embedded double quotes would break the query — collapse
+ * them to spaces rather than emit malformed KQL.
+ */
+export function searchPhrase(value) {
+  return `"${String(value).replace(/"/g, " ").trim()}"`;
+}
+
+// ---- Reusable schema fragments -------------------------------------------
+
+export const dateRangeSchema = z
+  .object({
+    start: z
+      .string()
+      .optional()
+      .describe("Inclusive start date/time, ISO 8601 (e.g. 2024-01-01)."),
+    end: z
+      .string()
+      .optional()
+      .describe("Inclusive end date/time, ISO 8601 (e.g. 2024-12-31)."),
+  })
+  .optional()
+  .describe("Optional date range filter.");
+
+export const recipientsSchema = z
+  .array(z.string())
+  .describe("List of recipient email addresses.");
+
+export const bodySchema = z
+  .object({
+    content: z.string().describe("Message body content."),
+    contentType: z
+      .enum(["text", "html"])
+      .optional()
+      .describe("Body content type. Defaults to 'text'."),
+  })
+  .describe("Message body.");
+
+/** Map a list of email strings to Graph recipient objects. */
+export function toRecipients(addresses = []) {
+  return addresses.map((address) => ({ emailAddress: { address } }));
+}
+
+/** Build a KQL fragment for an optional date range against a date property. */
+export function dateRangeKql(property, range) {
+  if (!range) return "";
+  const parts = [];
+  if (range.start) parts.push(`${property}>=${range.start}`);
+  if (range.end) parts.push(`${property}<=${range.end}`);
+  return parts.join(" AND ");
+}

--- a/m365-mcp/src/tools/util.js
+++ b/m365-mcp/src/tools/util.js
@@ -35,6 +35,19 @@ export function odataString(value) {
 }
 
 /**
+ * Encode a SharePoint site identifier for use as a URL path segment.
+ *
+ * Unlike {@link odataString}, this preserves the ':' '/' and ',' that Graph
+ * uses structurally in the two site-id forms — hostname:path
+ * (e.g. contoso.sharepoint.com:/sites/Team) and the composite
+ * host,siteCollectionId,siteId — while still escaping spaces and other unsafe
+ * characters.
+ */
+export function siteId(value) {
+  return encodeURI(String(value));
+}
+
+/**
  * Quote a value as a Graph `$search` phrase. The expression is wrapped in
  * double quotes, so embedded double quotes would break the query — collapse
  * them to spaces rather than emit malformed KQL.

--- a/m365-mcp/src/tools/util.js
+++ b/m365-mcp/src/tools/util.js
@@ -35,6 +35,16 @@ export function odataString(value) {
 }
 
 /**
+ * Escape a value for an OData single-quoted literal by doubling embedded
+ * single quotes — without percent-encoding. Use inside `users('...')`-style
+ * `@odata.bind` URLs, where the surrounding URL is parsed by Graph and normal
+ * UPN characters like `@` must stay literal.
+ */
+export function odataLiteral(value) {
+  return String(value).replace(/'/g, "''");
+}
+
+/**
  * Encode a SharePoint site identifier for use as a URL path segment.
  *
  * Unlike {@link odataString}, this preserves the ':' '/' and ',' that Graph

--- a/m365-mcp/test/smoke.test.js
+++ b/m365-mcp/test/smoke.test.js
@@ -1,0 +1,64 @@
+/**
+ * Smoke test: boots the real server in a child process and exercises the
+ * transport-level contract (health + bearer enforcement) end to end.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+
+const PORT = 38123;
+const BASE = `http://127.0.0.1:${PORT}`;
+
+/** Start src/index.js and resolve once it logs that it's listening. */
+async function startServer() {
+  const proc = spawn(process.execPath, ["src/index.js"], {
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  const ready = new Promise((resolve, reject) => {
+    proc.stdout.on("data", (chunk) => {
+      if (chunk.toString().includes("listening")) resolve();
+    });
+    proc.once("error", reject);
+    proc.once("exit", (code) =>
+      reject(new Error(`server exited early with code ${code}`)),
+    );
+  });
+
+  await Promise.race([
+    ready,
+    delay(5000).then(() => Promise.reject(new Error("server did not start in time"))),
+  ]);
+  return proc;
+}
+
+test("health and bearer enforcement", async (t) => {
+  const proc = await startServer();
+  t.after(() => proc.kill());
+
+  await t.test("GET /health is 200 ok", async () => {
+    const res = await fetch(`${BASE}/health`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.status, "ok");
+  });
+
+  await t.test("POST /mcp without a token is 401 / -32001", async () => {
+    const res = await fetch(`${BASE}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+    });
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error.code, -32001);
+  });
+
+  await t.test("GET /mcp is 405 (POST-only endpoint)", async () => {
+    const res = await fetch(`${BASE}/mcp`);
+    assert.equal(res.status, 405);
+  });
+});

--- a/m365-mcp/test/util.test.js
+++ b/m365-mcp/test/util.test.js
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 
 import {
   odataString,
+  odataLiteral,
   siteId,
   searchPhrase,
   dateRangeKql,
@@ -18,6 +19,11 @@ test("odataString doubles single quotes and percent-encodes", () => {
   assert.equal(odataString("inbox"), "inbox");
   assert.equal(odataString("a'b"), "a''b");
   assert.equal(odataString("a b"), "a%20b");
+});
+
+test("odataLiteral doubles single quotes without percent-encoding", () => {
+  assert.equal(odataLiteral("alice@contoso.com"), "alice@contoso.com");
+  assert.equal(odataLiteral("o'brien@contoso.com"), "o''brien@contoso.com");
 });
 
 test("siteId preserves Graph's structural ':' '/' ',' but escapes spaces", () => {

--- a/m365-mcp/test/util.test.js
+++ b/m365-mcp/test/util.test.js
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the pure helpers in src/tools/util.js.
+ * Run with `npm test` (uses the built-in node:test runner).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  odataString,
+  searchPhrase,
+  dateRangeKql,
+  toRecipients,
+} from "../src/tools/util.js";
+
+test("odataString doubles single quotes and percent-encodes", () => {
+  assert.equal(odataString("inbox"), "inbox");
+  assert.equal(odataString("a'b"), "a''b");
+  assert.equal(odataString("a b"), "a%20b");
+});
+
+test("searchPhrase wraps in quotes and strips embedded quotes", () => {
+  assert.equal(searchPhrase("hello world"), '"hello world"');
+  assert.equal(searchPhrase('say "hi"'), '"say  hi"');
+});
+
+test("dateRangeKql builds bounded clauses", () => {
+  assert.equal(dateRangeKql("received", undefined), "");
+  assert.equal(dateRangeKql("received", { start: "2024-01-01" }), "received>=2024-01-01");
+  assert.equal(
+    dateRangeKql("received", { start: "2024-01-01", end: "2024-12-31" }),
+    "received>=2024-01-01 AND received<=2024-12-31",
+  );
+});
+
+test("toRecipients maps addresses to Graph recipient objects", () => {
+  assert.deepEqual(toRecipients(["a@x.com", "b@x.com"]), [
+    { emailAddress: { address: "a@x.com" } },
+    { emailAddress: { address: "b@x.com" } },
+  ]);
+  assert.deepEqual(toRecipients(), []);
+});

--- a/m365-mcp/test/util.test.js
+++ b/m365-mcp/test/util.test.js
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 
 import {
   odataString,
+  siteId,
   searchPhrase,
   dateRangeKql,
   toRecipients,
@@ -17,6 +18,18 @@ test("odataString doubles single quotes and percent-encodes", () => {
   assert.equal(odataString("inbox"), "inbox");
   assert.equal(odataString("a'b"), "a''b");
   assert.equal(odataString("a b"), "a%20b");
+});
+
+test("siteId preserves Graph's structural ':' '/' ',' but escapes spaces", () => {
+  // hostname:path form — colon and slashes must stay literal.
+  assert.equal(
+    siteId("contoso.sharepoint.com:/sites/Team"),
+    "contoso.sharepoint.com:/sites/Team",
+  );
+  // composite host,siteCollectionId,siteId form — commas must stay literal.
+  assert.equal(siteId("contoso.sharepoint.com,abc,def"), "contoso.sharepoint.com,abc,def");
+  // spaces (e.g. in a path) are still escaped.
+  assert.equal(siteId("host:/sites/Team Site"), "host:/sites/Team%20Site");
 });
 
 test("searchPhrase wraps in quotes and strips embedded quotes", () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> New production-facing MCP service with write-capable Graph tools (mail, Teams, files, SharePoint) and bearer pass-through; mis-scoped tokens or gateway misconfiguration could cause broad tenant impact.
> 
> **Overview**
> Introduces a new **`m365-mcp`** Node service that exposes Microsoft 365 (Mail, Calendar, Teams, OneDrive, SharePoint) as MCP tools backed by Microsoft Graph.
> 
> The HTTP layer serves **`GET /health`** and **`POST /mcp`** (Streamable HTTP). Each MCP request must send **`Authorization: Bearer`**, and that token is forwarded to Graph with **no storage or exchange**; a new MCP server instance is created per request so callers stay isolated. **`graph.js`** adds timeouts, retry/backoff on throttling and transient errors, and caps in-memory file transfer size. Tool modules register dozens of zod-validated operations; failures are returned as MCP tool errors via **`runTool`**.
> 
> Packaging and ops include a multi-stage **Dockerfile** (Node 22, non-root user, `/health` check), **`.dockerignore` / `.tfyignore`**, **`deploy.py`** for TrueFoundry (`m365.mcp.truefoundry.com`), README, and **`node:test`** unit tests plus a smoke test for health and bearer enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c03dade7c896e55778bb0a5660994fb9c0f55690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->