### PR TITLE
Make Google Workspace MCP HTTP transport stateless

### DIFF
--- a/google-workspace/README.md
+++ b/google-workspace/README.md
@@ -29,7 +29,8 @@ The drive / docs / sheets / slides tool sets are ported verbatim from the upstre
 
 ## Architecture
 
-- **One Node process, 6 MCP endpoints.** Each `POST /mcp/<service>` request opens a session bound to a `StreamableHTTPServerTransport`, and the underlying MCP `Server` is created via `createMcpServer({ services: ['<service>'] })` so `tools/list` only returns that one service's tools.
+- **One Node process, 6 MCP endpoints.** Each `POST /mcp/<service>` request gets a fresh `StreamableHTTPServerTransport` and MCP `Server` instance via `createMcpServer({ services: ['<service>'] })`, so `tools/list` only returns that one service's tools.
+- **Stateless HTTP transport.** Transports are created with `sessionIdGenerator: undefined` (MCP SDK stateless mode). There is no in-memory session map, no `mcp-session-id` header handling, and no GET/DELETE session lifecycle routes — any pod replica can serve any request, which enables horizontal scaling without sticky sessions.
 - **Per-request OAuth (multi-tenant).** Every request must carry the end-user's Google access token in `Authorization: Bearer …`. The TFY Gateway runs the OAuth dance with Google and forwards the token. The server has no local OAuth flow, no on-disk token storage, no service-account fallback — credentials live in the gateway.
 - **Tool annotations.** Every `ToolDefinition` carries an explicit `annotations` object (see [Tool annotations](#tool-annotations)). The fields are hardcoded next to each tool so the wire shape is reviewable in the source.
 
@@ -53,7 +54,7 @@ src/
     calendar/             # index.ts + tools.ts + schemas.ts + helpers/
     gmail/                # index.ts + tools.ts + schemas.ts + helpers/
   transports/
-    http.ts               # Express app with 6 mounted MCP routes + /health
+    http.ts               # Express app, stateless POST-only MCP routes + /health
 Dockerfile
 deploy.py                 # TrueFoundry LocalSource(local_build=False) deploy
 ```
@@ -128,7 +129,7 @@ npm run start -- --port 3000 --host 127.0.0.1
 # In another shell, smoke-test:
 curl -s http://127.0.0.1:3000/health
 
-# Initialize an MCP session against one endpoint (header is required):
+# Smoke-test one endpoint (header is required; each POST is independent):
 curl -s -X POST http://127.0.0.1:3000/mcp/drive \
   -H "Authorization: Bearer <google-access-token>" \
   -H "Content-Type: application/json" \

--- a/google-workspace/src/index.ts
+++ b/google-workspace/src/index.ts
@@ -89,6 +89,7 @@ HTTP endpoints:
   /mcp/sheets       Google Sheets tools
   /mcp/slides       Google Slides tools
   /mcp/calendar     Google Calendar tools
+  /mcp/gmail        Gmail tools
 
 Authentication:
   Each request must carry an Authorization: Bearer <google-access-token>

--- a/google-workspace/src/transports/http.ts
+++ b/google-workspace/src/transports/http.ts
@@ -1,39 +1,23 @@
 /**
- * HTTP transport — mounts one StreamableHTTPServerTransport per service at
- * `/mcp/<service>`. Each mount exposes only its service's tools (via the
- * server factory) but shares a single Express app, one /health endpoint, and
- * per-request Bearer tokens forwarded by the TFY LLM Gateway.
+ * HTTP transport — mounts one stateless MCP endpoint per service at
+ * `/mcp/<service>`. Each POST request gets a fresh
+ * StreamableHTTPServerTransport (sessionIdGenerator: undefined) and MCP
+ * Server instance so any pod replica can handle any request without sticky
+ * sessions or in-memory session state.
  *
- * Session management is per-mount: each mount has its own map of session IDs
- * → transport+server pairs, keyed off the `mcp-session-id` header.
+ * Per-request Bearer tokens are forwarded by the TFY LLM Gateway.
  */
 
 import express from 'express';
-import { randomUUID } from 'crypto';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 
 import { log } from '../auth-ctx.js';
 import {
   SERVICE_KEYS,
-  SERVICES,
   VERSION,
   createMcpServer,
   type ServiceKey,
 } from '../server.js';
-
-interface HttpSession {
-  transport: StreamableHTTPServerTransport;
-  server: Server;
-}
-
-interface MountState {
-  sessions: Map<string, HttpSession>;
-  timers: Map<string, ReturnType<typeof setTimeout>>;
-}
-
-const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * Pull `Authorization: Bearer <token>` (if present) into `req.auth` so the
@@ -62,95 +46,39 @@ function bearerMiddleware(
   next();
 }
 
-function makeMountState(): MountState {
-  return { sessions: new Map(), timers: new Map() };
-}
+/**
+ * Handle one MCP request with a fresh transport + server. The MCP SDK requires
+ * a new stateless transport per request to avoid JSON-RPC message ID collisions.
+ */
+async function handleStatelessMcpRequest(
+  req: express.Request,
+  res: express.Response,
+  serviceKey: ServiceKey,
+): Promise<void> {
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  const server = createMcpServer({ services: [serviceKey] });
 
-function resetSessionTimer(
-  state: MountState,
-  sid: string,
-  idleTimeoutMs: number,
-): void {
-  const existing = state.timers.get(sid);
-  if (existing) clearTimeout(existing);
-  state.timers.set(
-    sid,
-    setTimeout(async () => {
-      const session = state.sessions.get(sid);
-      if (session) {
-        log(`Session idle timeout: ${sid}`);
-        await session.transport.close();
-        await session.server.close();
-        state.sessions.delete(sid);
-      }
-      state.timers.delete(sid);
-    }, idleTimeoutMs),
-  );
-}
-
-function clearSessionTimer(state: MountState, sid: string): void {
-  const timer = state.timers.get(sid);
-  if (timer) {
-    clearTimeout(timer);
-    state.timers.delete(sid);
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } finally {
+    await transport.close().catch((err) => {
+      log('Error closing transport', { error: (err as Error).message });
+    });
+    await server.close().catch((err) => {
+      log('Error closing server', { error: (err as Error).message });
+    });
   }
 }
 
-function mountServiceRoutes(
-  app: express.Express,
-  serviceKey: ServiceKey,
-  idleTimeoutMs: number,
-): MountState {
-  const state = makeMountState();
+function mountServiceRoutes(app: express.Express, serviceKey: ServiceKey): void {
   const path = `/mcp/${serviceKey}`;
-  const service = SERVICES[serviceKey];
 
   app.post(path, bearerMiddleware, async (req, res) => {
     try {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-
-      if (sessionId && state.sessions.has(sessionId)) {
-        const session = state.sessions.get(sessionId)!;
-        resetSessionTimer(state, sessionId, idleTimeoutMs);
-        await session.transport.handleRequest(req, res, req.body);
-        return;
-      }
-
-      if (!isInitializeRequest(req.body)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32600,
-            message: 'Bad Request: expected initialize request or valid session ID',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-      });
-      const sessionServer = createMcpServer({ services: [serviceKey] });
-      await sessionServer.connect(transport);
-
-      transport.onclose = () => {
-        const sid = transport.sessionId;
-        if (sid) {
-          clearSessionTimer(state, sid);
-          state.sessions.delete(sid);
-          log(`Session closed (${service.key}): ${sid}`);
-        }
-      };
-
-      await transport.handleRequest(req, res, req.body);
-
-      const sid = transport.sessionId;
-      if (sid) {
-        state.sessions.set(sid, { transport, server: sessionServer });
-        resetSessionTimer(state, sid, idleTimeoutMs);
-        log(`New session (${service.key}): ${sid}`);
-      }
+      await handleStatelessMcpRequest(req, res, serviceKey);
     } catch (error) {
       log(`Error handling POST ${path}`, { error: (error as Error).message });
       if (!res.headersSent) {
@@ -162,76 +90,13 @@ function mountServiceRoutes(
       }
     }
   });
-
-  app.get(path, bearerMiddleware, async (req, res) => {
-    try {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      if (!sessionId || !state.sessions.has(sessionId)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: { code: -32600, message: 'Bad Request: missing or invalid session ID' },
-          id: null,
-        });
-        return;
-      }
-      const session = state.sessions.get(sessionId)!;
-      resetSessionTimer(state, sessionId, idleTimeoutMs);
-      await session.transport.handleRequest(req, res);
-    } catch (error) {
-      log(`Error handling GET ${path}`, { error: (error as Error).message });
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        });
-      }
-    }
-  });
-
-  app.delete(path, bearerMiddleware, async (req, res) => {
-    try {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      if (!sessionId || !state.sessions.has(sessionId)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: { code: -32600, message: 'Bad Request: missing or invalid session ID' },
-          id: null,
-        });
-        return;
-      }
-      const session = state.sessions.get(sessionId)!;
-      await session.transport.close();
-      await session.server.close();
-      state.sessions.delete(sessionId);
-      res.status(200).end();
-    } catch (error) {
-      log(`Error handling DELETE ${path}`, { error: (error as Error).message });
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        });
-      }
-    }
-  });
-
-  return state;
-}
-
-export interface CreateHttpAppOptions {
-  sessionIdleTimeoutMs?: number;
 }
 
 export interface CreatedHttpApp {
   app: express.Express;
-  /** Per-service mount state, keyed by service key. */
-  states: Record<ServiceKey, MountState>;
 }
 
-export function createHttpApp(options?: CreateHttpAppOptions): CreatedHttpApp {
-  const idleTimeoutMs = options?.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS;
+export function createHttpApp(): CreatedHttpApp {
   const app = express();
   app.use(express.json({ limit: '50mb' }));
 
@@ -245,12 +110,11 @@ export function createHttpApp(options?: CreateHttpAppOptions): CreatedHttpApp {
     });
   });
 
-  const states = {} as Record<ServiceKey, MountState>;
   for (const key of SERVICE_KEYS) {
-    states[key] = mountServiceRoutes(app, key, idleTimeoutMs);
+    mountServiceRoutes(app, key);
   }
 
-  return { app, states };
+  return { app };
 }
 
 export interface StartHttpTransportArgs {
@@ -262,13 +126,13 @@ export async function startHttpTransport(args: StartHttpTransportArgs): Promise<
   try {
     const { httpHost, httpPort } = args;
     console.error(
-      `Starting Google Workspace MCP server (HTTP on ${httpHost}:${httpPort})...`,
+      `Starting Google Workspace MCP server (stateless HTTP on ${httpHost}:${httpPort})...`,
     );
     console.error(
       `Mounted endpoints: ${SERVICE_KEYS.map((k) => `/mcp/${k}`).join(', ')}`,
     );
 
-    const { app, states } = createHttpApp();
+    const { app } = createHttpApp();
 
     const httpServer = app.listen(httpPort, httpHost, () => {
       log(`HTTP server listening on ${httpHost}:${httpPort}`);
@@ -276,14 +140,6 @@ export async function startHttpTransport(args: StartHttpTransportArgs): Promise<
 
     const shutdown = async () => {
       log('Shutting down HTTP server...');
-      for (const key of SERVICE_KEYS) {
-        const state = states[key];
-        for (const [sid, session] of state.sessions) {
-          await session.transport.close();
-          await session.server.close();
-          state.sessions.delete(sid);
-        }
-      }
       httpServer.close();
       process.exit(0);
     };


### PR DESCRIPTION
## Summary

- Replaces the stateful Streamable HTTP session model (in-memory `mcp-session-id` maps, GET/DELETE lifecycle routes, 30-minute idle timers) with MCP SDK stateless mode (`sessionIdGenerator: undefined`).
- Each `POST /mcp/<service>` request now creates a fresh `StreamableHTTPServerTransport` + `Server`, handles the request, and tears down — no pod-local state between requests.
- Updates README architecture docs and CLI help to reflect stateless behavior.

## Why this matters

The previous transport kept per-mount `Map<sessionId, {transport, server}>` pairs in memory. That made the server stateful: subsequent requests had to hit the same pod (sticky sessions), sessions leaked memory until idle timeout, and rolling deploys dropped active sessions. Stateless mode lets any replica serve any request and scales to `replicas > 1` without a shared session store.

## Test plan

- [x] `npm run build` passes (typecheck + esbuild)
- [ ] Deploy to devtest and verify TFY Gateway MCP calls succeed against `/mcp/drive` (and other services)
- [ ] Confirm gateway client uses stateless POST-only flow (no `mcp-session-id` dependency)
- [ ] Smoke-test with curl: `POST /mcp/drive` initialize + tools/list as independent requests


Made with [Cursor](https://cursor.com)