### PR TITLE
MCP-982: stateless google workspace

### DIFF
--- a/google-workspace/src/transports/http.ts
+++ b/google-workspace/src/transports/http.ts
@@ -1,39 +1,23 @@
 /**
- * HTTP transport — mounts one StreamableHTTPServerTransport per service at
- * `/mcp/<service>`. Each mount exposes only its service's tools (via the
- * server factory) but shares a single Express app, one /health endpoint, and
- * per-request Bearer tokens forwarded by the TFY LLM Gateway.
+ * HTTP transport — mounts one stateless MCP endpoint per service at
+ * `/mcp/<service>`. Each POST request gets a fresh
+ * StreamableHTTPServerTransport (sessionIdGenerator: undefined) and MCP
+ * Server instance so any pod replica can handle any request without sticky
+ * sessions or in-memory session state.
  *
- * Session management is per-mount: each mount has its own map of session IDs
- * → transport+server pairs, keyed off the `mcp-session-id` header.
+ * Per-request Bearer tokens are forwarded by the TFY LLM Gateway.
  */
 
 import express from 'express';
-import { randomUUID } from 'crypto';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 
 import { log } from '../auth-ctx.js';
 import {
   SERVICE_KEYS,
-  SERVICES,
   VERSION,
   createMcpServer,
   type ServiceKey,
 } from '../server.js';
-
-interface HttpSession {
-  transport: StreamableHTTPServerTransport;
-  server: Server;
-}
-
-interface MountState {
-  sessions: Map<string, HttpSession>;
-  timers: Map<string, ReturnType<typeof setTimeout>>;
-}
-
-const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * Pull `Authorization: Bearer <token>` (if present) into `req.auth` so the
@@ -62,95 +46,39 @@ function bearerMiddleware(
   next();
 }
 
-function makeMountState(): MountState {
-  return { sessions: new Map(), timers: new Map() };
-}
+/**
+ * Handle one MCP request with a fresh transport + server. The MCP SDK requires
+ * a new stateless transport per request to avoid JSON-RPC message ID collisions.
+ */
+async function handleStatelessMcpRequest(
+  req: express.Request,
+  res: express.Response,
+  serviceKey: ServiceKey,
+): Promise<void> {
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  const server = createMcpServer({ services: [serviceKey] });
 
-function resetSessionTimer(
-  state: MountState,
-  sid: string,
-  idleTimeoutMs: number,
-): void {
-  const existing = state.timers.get(sid);
-  if (existing) clearTimeout(existing);
-  state.timers.set(
-    sid,
-    setTimeout(async () => {
-      const session = state.sessions.get(sid);
-      if (session) {
-        log(`Session idle timeout: ${sid}`);
-        await session.transport.close();
-        await session.server.close();
-        state.sessions.delete(sid);
-      }
-      state.timers.delete(sid);
-    }, idleTimeoutMs),
-  );
-}
-
-function clearSessionTimer(state: MountState, sid: string): void {
-  const timer = state.timers.get(sid);
-  if (timer) {
-    clearTimeout(timer);
-    state.timers.delete(sid);
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } finally {
+    await transport.close().catch((err) => {
+      log('Error closing transport', { error: (err as Error).message });
+    });
+    await server.close().catch((err) => {
+      log('Error closing server', { error: (err as Error).message });
+    });
   }
 }
 
-function mountServiceRoutes(
-  app: express.Express,
-  serviceKey: ServiceKey,
-  idleTimeoutMs: number,
-): MountState {
-  const state = makeMountState();
+function mountServiceRoutes(app: express.Express, serviceKey: ServiceKey): void {
   const path = `/mcp/${serviceKey}`;
-  const service = SERVICES[serviceKey];
 
   app.post(path, bearerMiddleware, async (req, res) => {
     try {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-
-      if (sessionId && state.sessions.has(sessionId)) {
-        const session = state.sessions.get(sessionId)!;
-        resetSessionTimer(state, sessionId, idleTimeoutMs);
-        await session.transport.handleRequest(req, res, req.body);
-        return;
-      }
-
-      if (!isInitializeRequest(req.body)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32600,
-            message: 'Bad Request: expected initialize request or valid session ID',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-      });
-      const sessionServer = createMcpServer({ services: [serviceKey] });
-      await sessionServer.connect(transport);
-
-      transport.onclose = () => {
-        const sid = transport.sessionId;
-        if (sid) {
-          clearSessionTimer(state, sid);
-          state.sessions.delete(sid);
-          log(`Session closed (${service.key}): ${sid}`);
-        }
-      };
-
-      await transport.handleRequest(req, res, req.body);
-
-      const sid = transport.sessionId;
-      if (sid) {
-        state.sessions.set(sid, { transport, server: sessionServer });
-        resetSessionTimer(state, sid, idleTimeoutMs);
-        log(`New session (${service.key}): ${sid}`);
-      }
+      await handleStatelessMcpRequest(req, res, serviceKey);
     } catch (error) {
       log(`Error handling POST ${path}`, { error: (error as Error).message });
       if (!res.headersSent) {
@@ -162,76 +90,13 @@ function mountServiceRoutes(
       }
     }
   });
-
-  app.get(path, bearerMiddleware, async (req, res) => {
-    try {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      if (!sessionId || !state.sessions.has(sessionId)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: { code: -32600, message: 'Bad Request: missing or invalid session ID' },
-          id: null,
-        });
-        return;
-      }
-      const session = state.sessions.get(sessionId)!;
-      resetSessionTimer(state, sessionId, idleTimeoutMs);
-      await session.transport.handleRequest(req, res);
-    } catch (error) {
-      log(`Error handling GET ${path}`, { error: (error as Error).message });
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        });
-      }
-    }
-  });
-
-  app.delete(path, bearerMiddleware, async (req, res) => {
-    try {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      if (!sessionId || !state.sessions.has(sessionId)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: { code: -32600, message: 'Bad Request: missing or invalid session ID' },
-          id: null,
-        });
-        return;
-      }
-      const session = state.sessions.get(sessionId)!;
-      await session.transport.close();
-      await session.server.close();
-      state.sessions.delete(sessionId);
-      res.status(200).end();
-    } catch (error) {
-      log(`Error handling DELETE ${path}`, { error: (error as Error).message });
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        });
-      }
-    }
-  });
-
-  return state;
-}
-
-export interface CreateHttpAppOptions {
-  sessionIdleTimeoutMs?: number;
 }
 
 export interface CreatedHttpApp {
   app: express.Express;
-  /** Per-service mount state, keyed by service key. */
-  states: Record<ServiceKey, MountState>;
 }
 
-export function createHttpApp(options?: CreateHttpAppOptions): CreatedHttpApp {
-  const idleTimeoutMs = options?.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS;
+export function createHttpApp(): CreatedHttpApp {
   const app = express();
   app.use(express.json({ limit: '50mb' }));
 
@@ -245,12 +110,11 @@ export function createHttpApp(options?: CreateHttpAppOptions): CreatedHttpApp {
     });
   });
 
-  const states = {} as Record<ServiceKey, MountState>;
   for (const key of SERVICE_KEYS) {
-    states[key] = mountServiceRoutes(app, key, idleTimeoutMs);
+    mountServiceRoutes(app, key);
   }
 
-  return { app, states };
+  return { app };
 }
 
 export interface StartHttpTransportArgs {
@@ -262,13 +126,13 @@ export async function startHttpTransport(args: StartHttpTransportArgs): Promise<
   try {
     const { httpHost, httpPort } = args;
     console.error(
-      `Starting Google Workspace MCP server (HTTP on ${httpHost}:${httpPort})...`,
+      `Starting Google Workspace MCP server (stateless HTTP on ${httpHost}:${httpPort})...`,
     );
     console.error(
       `Mounted endpoints: ${SERVICE_KEYS.map((k) => `/mcp/${k}`).join(', ')}`,
     );
 
-    const { app, states } = createHttpApp();
+    const { app } = createHttpApp();
 
     const httpServer = app.listen(httpPort, httpHost, () => {
       log(`HTTP server listening on ${httpHost}:${httpPort}`);
@@ -276,14 +140,6 @@ export async function startHttpTransport(args: StartHttpTransportArgs): Promise<
 
     const shutdown = async () => {
       log('Shutting down HTTP server...');
-      for (const key of SERVICE_KEYS) {
-        const state = states[key];
-        for (const [sid, session] of state.sessions) {
-          await session.transport.close();
-          await session.server.close();
-          state.sessions.delete(sid);
-        }
-      }
       httpServer.close();
       process.exit(0);
     };


### PR DESCRIPTION
Simple fix just removed session logic. Kept code consistent with the other servers. 

**_1. Why is the server stateful originally?_** 
I'm not sure why it was originally developed with state, but it has state with the session logic. 

**_2. Why does moving to stateless help?_** 
- Any replica can handle any request
- No session map; resources freed per request
- replicas > 1 works without extra infra
- POST-only, simpler routing (this doesn't mean that we can't GET or DELETE it just means everything is routed with POST, which is inline with our gateway anyway) 
- 
**_3. What changes are required to make Google MCPs stateless?_**
Only src/transports/http.ts needs to change. Tool handlers, auth, and service modules stay as-is.

Core transport change
Switch to MCP SDK stateless mode:

new StreamableHTTPServerTransport({
  sessionIdGenerator: undefined,  // stateless mode
});
On each POST /mcp/<service>:

Create a fresh transport + createMcpServer() instance
Connect them
Call transport.handleRequest(req, res, req.body)
Tear down transport + server in a finally block
The SDK requires a new transport per request in stateless mode — reusing one causes JSON-RPC message ID collisions.

Remove
Session maps (MountState, HttpSession)
30-minute idle timers
GET and DELETE handlers (session lifecycle / SSE streams tied to sessions)
Logic that rejects non-init requests without a valid mcp-session-id




Tested with curl command, tools are present: 

arnavdayal@Arnavs-MacBook-Air google-workspace % curl -s -X POST http://127.0.0.1:3000/mcp/drive \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' 
event: message
data: {"result":{"tools":[{"name":"search","annotations":{"readOnlyHint":true},"description":"Search for files in Google Drive. Set rawQuery=true to pass a raw Google Drive API query supporting operators like modifiedTime, createdTime, mimeType, name contains, etc.","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Search query. When rawQuery=true, this is passed directly to the Google Drive API as the q parameter."},"pageSize":{"type":"number","description":"Results per page (default 50, max 100)"},"pageToken":{"type":"string","description":"Token for next page of results"},"rawQuery":{"type":"boolean","description":"If true, pass query directly to Google Drive API without wrapping in fullText contains. Enables date filters, mimeType filters, etc."}},"required":["query"]}},{"name":"createTextFile","annotations":{"destructiveHint":false},"description":"Create a new text or markdown file","inputSchema":{"type":"object","properties":{"name":{"type":"string","description":"File name (.txt or .md)"},"content":{"type":"string","description":"File content"},"parentFolderId":{"type":"string","description":"Parent folder ID"}},"required":["name","content"]}},{"name":"updateTextFile","annotations":{"destructiveHint":true},"description":"Update an existing text or markdown file","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"ID of the file to update"},"content":{"type":"string","description":"New file content"},"name":{"type":"string","description":"New name (.txt or .md)"}},"required":["fileId","content"]}},{"name":"createFolder","annotations":{"destructiveHint":false},"description":"Create a new folder in Google Drive","inputSchema":{"type":"object","properties":{"name":{"type":"string","description":"Folder name"},"parent":{"type":"string","description":"Parent folder ID or path"}},"required":["name"]}},{"name":"listFolder","annotations":{"readOnlyHint":true},"description":"List contents of a folder (defaults to root)","inputSchema":{"type":"object","properties":{"folderId":{"type":"string","description":"Folder ID"},"pageSize":{"type":"number","description":"Items to return (default 50, max 100)"},"pageToken":{"type":"string","description":"Token for next page"}}}},{"name":"listSharedDrives","annotations":{"readOnlyHint":true},"description":"List available Google Shared Drives","inputSchema":{"type":"object","properties":{"pageSize":{"type":"number","description":"Drives to return (default 50, max 100)"},"pageToken":{"type":"string","description":"Token for next page"}}}},{"name":"deleteItem","annotations":{"destructiveHint":true},"description":"Move a file or folder to trash (can be restored from Google Drive trash)","inputSchema":{"type":"object","properties":{"itemId":{"type":"string","description":"ID of the item to delete"}},"required":["itemId"]}},{"name":"renameItem","annotations":{"destructiveHint":true},"description":"Rename a file or folder","inputSchema":{"type":"object","properties":{"itemId":{"type":"string","description":"ID of the item to rename"},"newName":{"type":"string","description":"New name"}},"required":["itemId","newName"]}},{"name":"moveItem","annotations":{"destructiveHint":true},"description":"Move a file or folder","inputSchema":{"type":"object","properties":{"itemId":{"type":"string","description":"ID of the item to move"},"destinationFolderId":{"type":"string","description":"Destination folder ID"}},"required":["itemId"]}},{"name":"copyFile","annotations":{"destructiveHint":true},"description":"Creates a copy of a Google Drive file or document","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"ID of the file to copy"},"newName":{"type":"string","description":"Name for the copied file. If not provided, will use 'Copy of [original name]'"},"parentFolderId":{"type":"string","description":"ID or path of the destination folder (defaults to same folder as original)"}},"required":["fileId"]}},{"name":"uploadFile","annotations":{"destructiveHint":false},"description":"Upload a local file (any type: image, audio, video, PDF, etc.) to Google Drive","inputSchema":{"type":"object","properties":{"localPath":{"type":"string","description":"Absolute path to the local file to upload"},"name":{"type":"string","description":"File name in Drive (defaults to local filename)"},"parentFolderId":{"type":"string","description":"Parent folder ID or path (e.g., '/Work/Projects'). Creates folders if needed. Defaults to root."},"mimeType":{"type":"string","description":"MIME type (auto-detected from extension if omitted)"},"convertToGoogleFormat":{"type":"boolean","description":"Convert uploaded file to Google Workspace format (e.g., .docx to Google Doc, .xlsx to Google Sheet, .pptx to Google Slides). Defaults to false."}},"required":["localPath"]}},{"name":"downloadFile","annotations":{"readOnlyHint":true},"description":"Download a Google Drive file to a local path. For Google Workspace files (Docs, Sheets, Slides, Drawings), exports to the specified format. For regular files, downloads as-is. Streams directly to disk.","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"},"localPath":{"type":"string","description":"Absolute local path to save the file (must start with /). Can be a directory (filename auto-resolved from Drive metadata) or a full file path. Path is normalized before use."},"exportMimeType":{"type":"string","description":"For Google Workspace files: MIME type to export as (e.g., 'application/pdf', 'text/csv'). Auto-detected from file extension if omitted. Ignored for non-Workspace files."},"overwrite":{"type":"boolean","description":"Whether to overwrite if file already exists at localPath. When false (default), returns an error instead of replacing the file."}},"required":["fileId","localPath"]}},{"name":"listPermissions","annotations":{"readOnlyHint":true},"description":"List sharing permissions for a file","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"}},"required":["fileId"]}},{"name":"addPermission","annotations":{"destructiveHint":false},"description":"Add a sharing permission to a file","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"},"emailAddress":{"type":"string","description":"Target user/group email"},"role":{"type":"string","enum":["owner","organizer","fileOrganizer","writer","commenter","reader"],"description":"Permission role"},"type":{"type":"string","enum":["user","group","domain","anyone"],"description":"Principal type"},"sendNotificationEmail":{"type":"boolean","description":"Send notification email"},"emailMessage":{"type":"string","description":"Custom message to include in the notification email. Ignored unless sendNotificationEmail is true."}},"required":["fileId","emailAddress"]}},{"name":"updatePermission","annotations":{"destructiveHint":true},"description":"Update an existing permission role","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"},"permissionId":{"type":"string","description":"Permission ID"},"role":{"type":"string","enum":["owner","organizer","fileOrganizer","writer","commenter","reader"],"description":"New role"}},"required":["fileId","permissionId","role"]}},{"name":"removePermission","annotations":{"destructiveHint":true},"description":"Remove a permission from a file (by permissionId or emailAddress)","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"},"permissionId":{"type":"string","description":"Permission ID"},"emailAddress":{"type":"string","description":"User email (alternative to permissionId)"}},"required":["fileId"]}},{"name":"shareFile","annotations":{"destructiveHint":false},"description":"Convenience wrapper to share a file with a user email","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"},"emailAddress":{"type":"string","description":"User email"},"role":{"type":"string","enum":["writer","commenter","reader"],"description":"Access role"},"sendNotificationEmail":{"type":"boolean","description":"Send notification email"},"emailMessage":{"type":"string","description":"Custom message to include in the notification email. Ignored unless sendNotificationEmail is true."}},"required":["fileId","emailAddress"]}},{"name":"convertPdfToGoogleDoc","annotations":{"destructiveHint":true},"description":"Convert an existing PDF in Drive into an editable Google Doc","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"PDF file ID in Google Drive"},"newName":{"type":"string","description":"Optional name for converted Doc"},"parentFolderId":{"type":"string","description":"Optional destination folder ID"}},"required":["fileId"]}},{"name":"bulkConvertFolderPdfs","annotations":{"destructiveHint":true},"description":"Convert all PDFs in a folder into Google Docs and return per-file results","inputSchema":{"type":"object","properties":{"folderId":{"type":"string","description":"Folder ID containing PDFs"},"maxResults":{"type":"number","description":"Maximum PDFs to process (1-200, default: 100)"},"continueOnError":{"type":"boolean","description":"Continue conversion when one file fails (default: true)"}},"required":["folderId"]}},{"name":"uploadPdfWithSplit","annotations":{"destructiveHint":false},"description":"Upload PDF and optionally split into chunked parts (metadata split plan for now)","inputSchema":{"type":"object","properties":{"localPath":{"type":"string","description":"Absolute path to local PDF"},"split":{"type":"boolean","description":"Enable split mode"},"maxPagesPerChunk":{"type":"number","description":"Target max pages per chunk (advisory metadata)"},"parentFolderId":{"type":"string","description":"Optional destination folder ID"},"namePrefix":{"type":"string","description":"Optional output name prefix"}},"required":["localPath"]}},{"name":"getRevisions","annotations":{"readOnlyHint":true},"description":"List revisions for a file","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"},"pageSize":{"type":"number","description":"Max revisions to return (default 50, max 200)"},"pageToken":{"type":"string","description":"Page token for pagination"}},"required":["fileId"]}},{"name":"restoreRevision","annotations":{"destructiveHint":true},"description":"Restore a file to a selected revision (creates a new head revision). Note: workspace files (Docs, Sheets, Slides) are restored via export/import and may lose some formatting.","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Google Drive file ID"},"revisionId":{"type":"string","description":"Revision ID to restore"},"confirm":{"type":"boolean","description":"Safety flag. Must be true to execute restore."}},"required":["fileId","revisionId"]}},{"name":"authTestFileAccess","annotations":{"destructiveHint":true},"description":"Run auth diagnostics against Drive API/file access","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"Optional file ID for targeted access check"}}}},{"name":"createShortcut","annotations":{"destructiveHint":false},"description":"Create a shortcut (link) to a file or folder in Google Drive. Useful for referencing the same document from multiple locations without duplicating it.","inputSchema":{"type":"object","properties":{"targetFileId":{"type":"string","description":"The file or folder ID (not a path) to create a shortcut to"},"parentFolderId":{"type":"string","description":"ID or path of the folder where the shortcut will be created"},"shortcutName":{"type":"string","description":"Custom name for the shortcut (defaults to original file name)"}},"required":["targetFileId"]}},{"name":"lockFile","annotations":{"destructiveHint":true},"description":"Lock a file to prevent editing by setting content restrictions. The file remains readable but cannot be modified until unlocked.","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"ID of the file to lock"},"reason":{"type":"string","description":"Reason for locking the file (shown to users who try to edit)"},"ownerRestricted":{"type":"boolean","description":"If true, only the file owner can unlock the file (default: false)"}},"required":["fileId"]}},{"name":"unlockFile","annotations":{"destructiveHint":true},"description":"Unlock a previously locked file by removing content restrictions, restoring full edit access.","inputSchema":{"type":"object","properties":{"fileId":{"type":"string","description":"ID of the file to unlock"}},"required":["fileId"]}}]},"jsonrpc":"2.0","id":1}


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MCP HTTP surface (POST-only, no session continuation via GET/DELETE), which could break clients that relied on sticky sessions, though it matches the TFY gateway model; per-request server lifecycle is a moderate operational/performance shift but required for safe stateless SDK use.
> 
> **Overview**
> Refactors the Google Workspace MCP **HTTP transport** from session-based routing to **stateless POST-only** handling so any replica can serve any request without sticky sessions or in-memory session maps.
> 
> Each `POST /mcp/<service>` now spins up a fresh `StreamableHTTPServerTransport` with `sessionIdGenerator: undefined`, connects a new `createMcpServer` instance, runs `handleRequest`, and tears both down in a `finally` block. Removed are per-mount session storage, 30-minute idle timers, `mcp-session-id` routing, initialize-only gating, and the **GET/DELETE** lifecycle handlers. **`createHttpApp`** no longer exposes mount `states` or `sessionIdleTimeoutMs`; shutdown no longer walks open sessions. Bearer token forwarding and `/health` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f76285411f6618db2bc64989b61b0d188df73b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->