### PR TITLE
feat(m365): expose Teams hosted images

### DIFF
--- a/m365-mcp/README.md
+++ b/m365-mcp/README.md
@@ -67,6 +67,7 @@ malformed headers return JSON-RPC error `-32001` with HTTP 401.
 | `list_chats` | List the user's chats |
 | `search_chat_messages` | Search across chat messages |
 | `get_chat_messages` | Get messages from a chat |
+| `get_chat_message_hosted_content` | Download an image embedded in a chat message |
 | `send_chat_message` | Post a message to a chat |
 | `create_chat` | Create a new chat |
 | `add_chat_member` | Add a member to a chat |

--- a/m365-mcp/src/tools/teams.js
+++ b/m365-mcp/src/tools/teams.js
@@ -3,8 +3,8 @@
  */
 
 import { z } from "zod";
-import { graphGet, graphPost, microsoftSearch } from "../graph.js";
-import { runTool, odataString, odataLiteral } from "./util.js";
+import { graphDownload, graphGet, graphPost, microsoftSearch } from "../graph.js";
+import { image, runTool, odataString, odataLiteral } from "./util.js";
 
 /** Build an aadUserConversationMember bind for a user UPN/id. */
 function memberBind(userIdOrUpn) {
@@ -69,6 +69,28 @@ export function registerTeamsTools(server, token) {
         $top: top ?? 25,
         $orderby: "createdDateTime desc",
       }),
+    ),
+  );
+
+  server.tool(
+    "get_chat_message_hosted_content",
+    "Download an image embedded in a Teams chat message. Use the hosted " +
+      "content id from the message body's image source.",
+    {
+      chat_id: z.string().describe("The chat id."),
+      message_id: z.string().describe("The chat message id."),
+      hosted_content_id: z
+        .string()
+        .describe("The hosted content id from the message body's image source."),
+    },
+    runTool(
+      ({ chat_id, message_id, hosted_content_id }) =>
+        graphDownload(
+          token,
+          `/chats/${odataString(chat_id)}/messages/${odataString(message_id)}` +
+            `/hostedContents/${odataString(hosted_content_id)}/$value`,
+        ),
+      image,
     ),
   );
 

--- a/m365-mcp/src/tools/util.js
+++ b/m365-mcp/src/tools/util.js
@@ -11,14 +11,31 @@ export function ok(data) {
   return { content: [{ type: "text", text }] };
 }
 
+/** Build an MCP image result from a bounded Graph download. */
+export function image(data) {
+  const mimeType = String(data?.contentType || "")
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+  if (!mimeType.startsWith("image/")) {
+    throw new GraphError(
+      415,
+      `Expected image content, but Graph returned ${mimeType || "an unknown content type"}.`,
+    );
+  }
+  return {
+    content: [{ type: "image", data: data.base64, mimeType }],
+  };
+}
+
 /**
  * Wrap an async tool handler so Graph/runtime failures become readable MCP
  * tool errors instead of throwing out of the transport.
  */
-export function runTool(handler) {
+export function runTool(handler, formatter = ok) {
   return async (args) => {
     try {
-      return ok(await handler(args ?? {}));
+      return formatter(await handler(args ?? {}));
     } catch (err) {
       const message =
         err instanceof GraphError

--- a/m365-mcp/test/teams.test.js
+++ b/m365-mcp/test/teams.test.js
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for Microsoft Teams tool registration and hosted-image retrieval.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { registerTeamsTools } from "../src/tools/teams.js";
+
+function registeredTeamsTools(token = "test-token") {
+  const tools = new Map();
+  const server = {
+    tool(name, description, schema, handler) {
+      tools.set(name, { description, schema, handler });
+    },
+  };
+  registerTeamsTools(server, token);
+  return tools;
+}
+
+test("get_chat_message_hosted_content returns Graph image bytes as MCP image content", async (t) => {
+  const tools = registeredTeamsTools();
+  const tool = tools.get("get_chat_message_hosted_content");
+  assert.ok(tool, "hosted-content tool should be registered");
+
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  let request;
+  globalThis.fetch = async (url, init) => {
+    request = { url: String(url), init };
+    return new Response(Uint8Array.from([0x89, 0x50, 0x4e, 0x47]), {
+      status: 200,
+      headers: { "Content-Type": "image/png" },
+    });
+  };
+
+  const result = await tool.handler({
+    chat_id: "chat/id",
+    message_id: "message id",
+    hosted_content_id: "hosted/content",
+  });
+
+  assert.equal(
+    request.url,
+    "https://graph.microsoft.com/v1.0/chats/chat%2Fid/messages/message%20id/hostedContents/hosted%2Fcontent/$value",
+  );
+  assert.equal(request.init.headers.Authorization, "Bearer test-token");
+  assert.deepEqual(result, {
+    content: [
+      {
+        type: "image",
+        data: "iVBORw==",
+        mimeType: "image/png",
+      },
+    ],
+  });
+});
+
+test("get_chat_message_hosted_content rejects non-image hosted content", async (t) => {
+  const tool = registeredTeamsTools().get("get_chat_message_hosted_content");
+  assert.ok(tool, "hosted-content tool should be registered");
+
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async () =>
+    new Response("not an image", {
+      status: 200,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+
+  const result = await tool.handler({
+    chat_id: "chat",
+    message_id: "message",
+    hosted_content_id: "hosted",
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /expected image content/i);
+  assert.doesNotMatch(result.content[0].text, /not an image/i);
+});


### PR DESCRIPTION
## What changed

- add `get_chat_message_hosted_content` to the M365 Teams tools
- download Graph hosted-content bytes through the existing bounded downloader
- return image MIME types as native MCP image content
- reject non-image hosted content without returning its body
- document the new tool and add focused tests

## Why

`get_chat_messages` returns the HTML reference for an inline Teams image, but the MCP server had no way to retrieve the referenced hosted-content bytes. Agents therefore could not inspect screenshots without falling back to UI automation.

The new tool uses the caller's existing delegated Microsoft Graph token and the documented `/chats/{chat-id}/messages/{message-id}/hostedContents/{hosted-content-id}/$value` endpoint.

## Validation

- `npm test` — 12 tests passed
- `git diff --check` — clean
- TDD coverage verifies URL encoding, delegated bearer propagation, MCP image output, and fail-closed handling for non-image content

## Follow-up acceptance

After deployment, validate one real Teams inline image through the managed M365 MCP. No live Graph token or hosted-content URL is included in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Teams read path reusing existing download limits and delegated tokens; no auth or persistence changes.
> 
> **Overview**
> Adds **`get_chat_message_hosted_content`** so agents can fetch inline Teams chat images referenced in message HTML, using Graph `hostedContents/{id}/$value` via the existing bounded **`graphDownload`** path.
> 
> Tool results use a new **`image`** MCP formatter (optional second argument on **`runTool`**) that returns native image content for `image/*` responses and **fail-closed** tool errors for other MIME types without surfacing the body. README lists the tool; **`teams.test.js`** covers URL encoding, bearer token, image output, and non-image rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b7f056ab04b5f384a988f16ecb3da724248d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->